### PR TITLE
Admin/feat/update-default-model

### DIFF
--- a/pkg/api/handlers/model.go
+++ b/pkg/api/handlers/model.go
@@ -204,9 +204,17 @@ func validateModelManifestAndSetDefaults(ctx context.Context, c kclient.Client, 
 			return err
 		}
 
+		if newModel.Spec.Manifest.Default && !newModel.Spec.Manifest.Active {
+			return types.NewErrBadRequest("model must be active to be set as default model")
+		}
+
 		for _, model := range modelList.Items {
 			if model.Spec.Manifest.Default && model.Spec.Manifest.Active && model.Name != newModel.Name {
-				return types.NewErrBadRequest("model %s is already the default model", model.Name)
+				model.Spec.Manifest.Default = false
+
+				if err := c.Update(ctx, &model); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/ui/admin/app/components/composed/ConfirmationDialog.tsx
+++ b/ui/admin/app/components/composed/ConfirmationDialog.tsx
@@ -23,7 +23,7 @@ export function ConfirmationDialog({
     children?: ReactNode;
     title: ReactNode;
     description?: ReactNode;
-    onConfirm: () => void;
+    onConfirm: (e: React.MouseEvent) => void;
     onCancel?: () => void;
     confirmProps?: Omit<Partial<ComponentProps<typeof Button>>, "onClick">;
 }) {

--- a/ui/admin/app/components/model/DeleteModel.tsx
+++ b/ui/admin/app/components/model/DeleteModel.tsx
@@ -28,7 +28,10 @@ export function DeleteModel(props: DeleteModelProps) {
                 <ConfirmationDialog
                     title="Are you sure you want to delete this model?"
                     description="Doing so will break any tools or agents currently using it."
-                    onConfirm={() => deleteModel.execute(props.id)}
+                    onConfirm={(e) => {
+                        e.stopPropagation();
+                        deleteModel.execute(props.id);
+                    }}
                     confirmProps={{
                         variant: "destructive",
                         children: "Delete",

--- a/ui/admin/app/components/model/ModelForm.tsx
+++ b/ui/admin/app/components/model/ModelForm.tsx
@@ -188,6 +188,11 @@ export function ModelForm(props: ModelFormProps) {
                     control={form.control}
                     name="default"
                     label="Default Model"
+                    description={
+                        form.watch("default")
+                            ? "Checking this box will override the existing default model for all assistants."
+                            : null
+                    }
                 />
 
                 <Button

--- a/ui/admin/app/lib/model/models.ts
+++ b/ui/admin/app/lib/model/models.ts
@@ -21,6 +21,8 @@ export const getModelUsageLabel = (usage: string) => {
     return ModelUsageLabels[usage as ModelUsage];
 };
 
+export type ModelUpdateParams = { updateDefaults?: boolean };
+
 export type ModelManifest = {
     name?: string;
     targetModel?: string;

--- a/ui/admin/app/lib/routers/apiRoutes.ts
+++ b/ui/admin/app/lib/routers/apiRoutes.ts
@@ -1,6 +1,7 @@
 import queryString from "query-string";
 import { mutate } from "swr";
 
+import { ModelUpdateParams } from "~/lib/model/models";
 import { ToolReferenceType } from "~/lib/model/toolReferences";
 import { ApiUrl } from "~/lib/routers/baseRouter";
 
@@ -163,8 +164,10 @@ export const ApiRoutes = {
         base: () => buildUrl("/models"),
         getModels: () => buildUrl("/models"),
         getModelById: (modelId: string) => buildUrl(`/models/${modelId}`),
-        createModel: () => buildUrl(`/models`),
-        updateModel: (modelId: string) => buildUrl(`/models/${modelId}`),
+        createModel: (params?: ModelUpdateParams) =>
+            buildUrl(`/models`, params),
+        updateModel: (modelId: string, params?: ModelUpdateParams) =>
+            buildUrl(`/models/${modelId}`, params),
         deleteModel: (modelId: string) => buildUrl(`/models/${modelId}`),
     },
 };

--- a/ui/admin/app/lib/service/api/modelApiService.ts
+++ b/ui/admin/app/lib/service/api/modelApiService.ts
@@ -44,7 +44,7 @@ getModelProviders.key = () => ({
 async function createModel(manifest: ModelManifest) {
     await new Promise((resolve) => setTimeout(resolve, 1000));
     const { data } = await request<Model>({
-        url: ApiRoutes.models.createModel().url,
+        url: ApiRoutes.models.createModel({ updateDefaults: true }).url,
         method: "POST",
         data: manifest,
     });
@@ -56,7 +56,8 @@ async function updateModel(modelId: string, manifest: ModelManifest) {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     const { data } = await request<Model>({
-        url: ApiRoutes.models.updateModel(modelId).url,
+        url: ApiRoutes.models.updateModel(modelId, { updateDefaults: true })
+            .url,
         method: "PUT",
         data: manifest,
     });

--- a/ui/admin/app/routes/_auth.models.tsx
+++ b/ui/admin/app/routes/_auth.models.tsx
@@ -81,6 +81,10 @@ export default function Models() {
                 id: "id",
                 header: "Model",
             }),
+            columnHelper.accessor((model) => model.usage as string, {
+                id: "usage",
+                header: "Usage",
+            }),
             columnHelper.accessor(
                 (model) =>
                     providerMap[model.modelProvider] ?? model.modelProvider,


### PR DESCRIPTION
addresses #603

Updates to models:
- allow admins to set default model without deselecting the previous default
- prevent edit model from opening when deleting model
- add model usage column to models table

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>