### PR TITLE
fix: add padding to oauth app forms

### DIFF
--- a/ui/admin/app/components/agent/Publish.tsx
+++ b/ui/admin/app/components/agent/Publish.tsx
@@ -22,11 +22,7 @@ type PublishProps = {
     onPublish: (alias: string) => void;
 };
 
-export function Publish({
-    className,
-    alias: _alias,
-    onPublish,
-}: PublishProps) {
+export function Publish({ className, alias: _alias, onPublish }: PublishProps) {
     const [alias, setAlias] = useState(_alias);
 
     const handlePublish = () => onPublish(alias);

--- a/ui/admin/app/components/oauth-apps/OAuthAppForm.tsx
+++ b/ui/admin/app/components/oauth-apps/OAuthAppForm.tsx
@@ -60,7 +60,7 @@ export function OAuthAppForm({ type, onSubmit, isLoading }: OAuthAppFormProps) {
 
     return (
         <Form {...form}>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-1">
                 {spec.steps.map((s, i) => (
                     <Fragment key={i}>{renderStep(s)}</Fragment>
                 ))}


### PR DESCRIPTION
Prior to this change, the spacing cut off the border on the x-axis. This change makes a little space, so the border highlighting appears all the way around.

Issue: https://github.com/otto8-ai/otto8/issues/612