### PR TITLE
chore: change webhook password field to token

### DIFF
--- a/apiclient/types/webhook.go
+++ b/apiclient/types/webhook.go
@@ -5,6 +5,7 @@ type Webhook struct {
 	WebhookManifest
 	AliasAssigned              bool  `json:"aliasAssigned,omitempty"`
 	LastSuccessfulRunCompleted *Time `json:"lastSuccessfulRunCompleted,omitempty"`
+	HasToken                   bool  `json:"hasToken,omitempty"`
 }
 
 type WebhookManifest struct {


### PR DESCRIPTION
This change also adds a HasToken field to the API since the API doesn't return the hashed token.