### PR TITLE
chore: add padding to custom oauth app form

### DIFF
--- a/ui/admin/app/components/oauth-apps/custom/CustomOAuthAppForm.tsx
+++ b/ui/admin/app/components/oauth-apps/custom/CustomOAuthAppForm.tsx
@@ -162,7 +162,7 @@ export function CustomOAuthAppForm({
         <Form {...form}>
             <form
                 onSubmit={handleSubmit}
-                className="space-y-4 overflow-x-hidden"
+                className="space-y-4 overflow-x-hidden p-1"
             >
                 {step === Step.NAME && (
                     <>


### PR DESCRIPTION
The border for the focused form input will be completely visible with this padding.

Issue: https://github.com/otto8-ai/otto8/issues/624