### PR TITLE
change: use cleanup handler for runstate instead of finalizer on a run

### DIFF
--- a/pkg/controller/handlers/runs/runs.go
+++ b/pkg/controller/handlers/runs/runs.go
@@ -9,8 +9,6 @@ import (
 	"github.com/otto8-ai/otto8/pkg/invoke"
 	v1 "github.com/otto8-ai/otto8/pkg/storage/apis/otto.otto8.ai/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var log = logger.Package()
@@ -21,16 +19,6 @@ type Handler struct {
 
 func New(invoker *invoke.Invoker) *Handler {
 	return &Handler{invoker: invoker}
-}
-
-func (*Handler) DeleteRunState(req router.Request, resp router.Response) error {
-	run := req.Object.(*v1.Run)
-	return client.IgnoreNotFound(req.Delete(&v1.RunState{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      run.Name,
-			Namespace: run.Namespace,
-		},
-	}))
 }
 
 func (h *Handler) Resume(req router.Request, _ router.Response) error {

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -37,9 +37,11 @@ func (c *Controller) setupRoutes() error {
 	oauthLogins := oauthapp.NewLogin(c.services.Invoker, c.services.ServerURL)
 
 	// Runs
-	root.Type(&v1.Run{}).FinalizeFunc(v1.RunFinalizer, runs.DeleteRunState)
 	root.Type(&v1.Run{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.Run{}).HandlerFunc(runs.Resume)
+
+	// RunStates
+	root.Type(&v1.RunState{}).HandlerFunc(cleanup.Cleanup)
 
 	// Threads
 	root.Type(&v1.Thread{}).HandlerFunc(cleanup.Cleanup)

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -37,6 +37,7 @@ func (c *Controller) setupRoutes() error {
 	oauthLogins := oauthapp.NewLogin(c.services.Invoker, c.services.ServerURL)
 
 	// Runs
+	root.Type(&v1.Run{}).HandlerFunc(runs.MigrateRemoveRunFinalizer) // to be removed
 	root.Type(&v1.Run{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.Run{}).HandlerFunc(runs.Resume)
 

--- a/pkg/invoke/invoker.go
+++ b/pkg/invoke/invoker.go
@@ -345,7 +345,6 @@ func (i *Invoker) createRun(ctx context.Context, c kclient.WithWatch, thread *v1
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: system.RunPrefix,
 			Namespace:    thread.Namespace,
-			Finalizers:   []string{v1.RunFinalizer},
 		},
 		Spec: v1.RunSpec{
 			Synchronous:           opts.Synchronous,

--- a/pkg/storage/apis/otto.otto8.ai/v1/run.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/run.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	RunFinalizer               = "otto.otto8.ai/run"
+	RunFinalizer               = "otto.otto8.ai/run" // to be removed
 	KnowledgeFileFinalizer     = "otto.otto8.ai/knowledge-file"
 	WorkspaceFinalizer         = "otto.otto8.ai/workspace"
 	KnowledgeSetFinalizer      = "otto.otto8.ai/knowledge-set"

--- a/pkg/storage/apis/otto.otto8.ai/v1/runstate.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/runstate.go
@@ -25,7 +25,9 @@ type RunStateSpec struct {
 }
 
 func (in *RunState) DeleteRefs() []Ref {
-	return []Ref{}
+	return []Ref{
+		{ObjType: &Run{}, Name: in.Name, Namespace: in.Namespace},
+	}
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Finalizers can be a PITA and leave over dangling refs.
We've also seen RunStates hanging around while their Runs were already gone.
This change switches RunStates over to the same cleanup logic we use for most other objects.