### PR TITLE
fix: webhooks getting not found error when triggering workflows

### DIFF
--- a/pkg/api/handlers/webhooks.go
+++ b/pkg/api/handlers/webhooks.go
@@ -137,7 +137,7 @@ func convertWebhook(webhook v1.Webhook, urlPrefix string) *types.Webhook {
 		if webhook.Status.AliasAssigned {
 			path = webhook.Spec.Alias
 		}
-		links = []string{"invoke", fmt.Sprintf("%s/webhooks/%s", urlPrefix, path)}
+		links = []string{"invoke", fmt.Sprintf("%s/webhooks/%s/%s", urlPrefix, webhook.Namespace, path)}
 	}
 
 	manifest := webhook.Spec.WebhookManifest
@@ -195,7 +195,7 @@ func (a *WebhookHandler) RemoveToken(req api.Context) error {
 
 func (a *WebhookHandler) Execute(req api.Context) error {
 	var webhook v1.Webhook
-	if err := alias.Get(req.Context(), req.Storage, &webhook, req.Namespace(), req.PathValue("id")); err != nil {
+	if err := alias.Get(req.Context(), req.Storage, &webhook, req.PathValue("namespace"), req.PathValue("id")); err != nil {
 		return err
 	}
 

--- a/pkg/api/handlers/webhooks.go
+++ b/pkg/api/handlers/webhooks.go
@@ -195,7 +195,7 @@ func (a *WebhookHandler) RemoveToken(req api.Context) error {
 
 func (a *WebhookHandler) Execute(req api.Context) error {
 	var webhook v1.Webhook
-	if err := alias.Get(req.Context(), req.Storage, &webhook, "", req.PathValue("id")); err != nil {
+	if err := alias.Get(req.Context(), req.Storage, &webhook, req.Namespace(), req.PathValue("id")); err != nil {
 		return err
 	}
 

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -186,8 +186,8 @@ func Router(services *services.Services) (http.Handler, error) {
 	mux.HandleFunc("GET /api/webhooks/{id}", webhooks.ByID)
 	mux.HandleFunc("DELETE /api/webhooks/{id}", webhooks.Delete)
 	mux.HandleFunc("PUT /api/webhooks/{id}", webhooks.Update)
-	mux.HandleFunc("POST /api/webhooks/{id}", webhooks.Execute)
 	mux.HandleFunc("POST /api/webhooks/{id}/remove-token", webhooks.RemoveToken)
+	mux.HandleFunc("POST /api/webhooks/{namespace}/{id}", webhooks.Execute)
 
 	// Email Receivers
 	mux.HandleFunc("POST /api/email-receivers", emailreceiver.Create)


### PR DESCRIPTION
This PR fixes the issue where a webhook execution throws a not found error.

This fix solves that by providing the default namespace to the workflow execution handler.

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>