### PR TITLE
Chore: setup postgres and vector in dockerfile

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+check_postgres_active() {
+  for i in {1..30}; do
+    if pg_isready -q; then
+      echo "PostgreSQL is active and ready!"
+      return 0
+    fi
+    echo "Waiting for PostgreSQL to become active... ($i/10)"
+    sleep 2
+  done
+  echo "PostgreSQL did not become active in time."
+  exit 1
+}
+
+if [ "$OPENAI_API_KEY" = "" ]; then
+    echo OPENAI_API_KEY env is required to be set
+    exit 1
+fi
+mkdir -p /run/sshd
+/usr/sbin/sshd -D &
+mkdir -p /data/cache
+# This is YAML
+export OTTO8_SERVER_VERSIONS="$(cat <<VERSIONS
+"github.com/otto8-ai/tools": "$(cd /otto8-tools && git rev-parse HEAD)"
+"github.com/gptscript-ai/workspace-provider": "$(cd /otto8-tools/workspace-provider && git rev-parse HEAD)"
+"github.com/gptscript-ai/datasets": "$(cd /otto8-tools/datasets && git rev-parse HEAD)"
+"github.com/kubernetes-sigs/aws-encryption-provider": "$(cd /otto8-tools/aws-encryption-provider && git rev-parse HEAD)"
+# double echo to remove trailing whitespace
+"chrome": "$(echo $(/opt/google/chrome/chrome --version))"
+VERSIONS
+)"
+
+if [ -z "$OTTO8_SERVER_DSN" ]; then
+  echo "OTTO8_SERVER_DSN is not set. Starting PostgreSQL process..."
+
+  # Start PostgreSQL in the background
+  echo "Starting PostgreSQL server..."
+  /usr/bin/docker-entrypoint.sh postgres &
+
+  check_postgres_active
+  export OTTO8_SERVER_DSN="postgresql://otto8:otto8@localhost:5432/otto8"
+fi
+
+exec tini -- otto8 server


### PR DESCRIPTION
This PR should configure postgres and pgvector into otto dockerfile. It will run and use the built-in postgres process if no OTTO8_SERVER_DSN is set.

I ran some test against knowledge ingestion and it works fine. 