### PR TITLE
enhance: turn up the heat in the agent/workflow name generation

### DIFF
--- a/ui/admin/app/lib/service/nameGenerator.ts
+++ b/ui/admin/app/lib/service/nameGenerator.ts
@@ -1,12 +1,10 @@
 import { faker } from "@faker-js/faker";
 
-export function generateRandomName(): string {
-    // faker doesn't have a "capitalized word" function, so we need to do it manually :(
-    const rawAdjective = faker.word.adjective();
-    const rawAnimal = faker.animal.type();
-    const adjective =
-        rawAdjective.charAt(0).toUpperCase() + rawAdjective.slice(1);
-    const animal = rawAnimal.charAt(0).toUpperCase() + rawAnimal.slice(1);
+const uppercaseFirst = (word: string) =>
+    word.charAt(0).toUpperCase() + word.slice(1);
 
-    return `${adjective} ${animal}`;
+export function generateRandomName(): string {
+    return [faker.word.adjective(), faker.word.noun()]
+        .map(uppercaseFirst)
+        .join(" ");
 }


### PR DESCRIPTION
Now uses the `noun` method instead of `animal` for generating the subject of an agent name