### PR TITLE
Fix: use base 2 to calculate filesize

### DIFF
--- a/ui/admin/app/components/knowledge/FileTree.tsx
+++ b/ui/admin/app/components/knowledge/FileTree.tsx
@@ -410,14 +410,14 @@ export default function FileTreeNode({
                                 </div>
                                 <span className="text-xs flex items-center justify-center text-muted-foreground">
                                     {node.file.sizeInBytes
-                                        ? node.file.sizeInBytes > 1000000
+                                        ? node.file.sizeInBytes > 1024 * 1024
                                             ? (
                                                   node.file.sizeInBytes /
-                                                  1000000
+                                                  (1024 * 1024)
                                               ).toFixed(2) + " MB"
-                                            : node.file.sizeInBytes > 1000
+                                            : node.file.sizeInBytes > 1024
                                               ? (
-                                                    node.file.sizeInBytes / 1000
+                                                    node.file.sizeInBytes / 1024
                                                 ).toFixed(2) + " KB"
                                               : node.file.sizeInBytes + " Bytes"
                                         : "0 Bytes"}
@@ -455,11 +455,12 @@ export default function FileTreeNode({
                                     </span>
                                 </div>
                                 <div className="whitespace-nowrap text-xs">
-                                    {totalSize > 1000000
-                                        ? (totalSize / 1000000).toFixed(2) +
-                                          " MB"
-                                        : totalSize > 1000
-                                          ? (totalSize / 1000).toFixed(2) +
+                                    {totalSize > 1024 * 1024
+                                        ? ((totalSize / 1024) * 1024).toFixed(
+                                              2
+                                          ) + " MB"
+                                        : totalSize > 1024
+                                          ? (totalSize / 1024).toFixed(2) +
                                             " KB"
                                           : totalSize + " Bytes"}
                                 </div>


### PR DESCRIPTION
Although it is never clear when to use base 2/ base 10 to calculate file size, onedrive seems to be doing with base 2. So avoid confusion, we should use base 2 too.

https://github.com/otto8-ai/otto8/issues/659