### PR TITLE
fix: don't assume uncached.Get works in the invoker

### DIFF
--- a/apiclient/types/zz_generated.deepcopy.go
+++ b/apiclient/types/zz_generated.deepcopy.go
@@ -693,6 +693,16 @@ func (in *KnowledgeSourceManifest) DeepCopyInto(out *KnowledgeSourceManifest) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.FilePathPrefixInclude != nil {
+		in, out := &in.FilePathPrefixInclude, &out.FilePathPrefixInclude
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.FilePathPrefixExclude != nil {
+		in, out := &in.FilePathPrefixExclude, &out.FilePathPrefixExclude
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	in.KnowledgeSourceInput.DeepCopyInto(&out.KnowledgeSourceInput)
 }
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -1376,6 +1376,34 @@ func schema_otto8_ai_otto8_apiclient_types_KnowledgeSource(ref common.ReferenceC
 							Format: "",
 						},
 					},
+					"filePathPrefixInclude": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+					"filePathPrefixExclude": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"onedriveConfig": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("github.com/otto8-ai/otto8/apiclient/types.OneDriveConfig"),
@@ -1519,6 +1547,34 @@ func schema_otto8_ai_otto8_apiclient_types_KnowledgeSourceManifest(ref common.Re
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",
+						},
+					},
+					"filePathPrefixInclude": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+					"filePathPrefixExclude": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
 						},
 					},
 					"onedriveConfig": {


### PR DESCRIPTION
The uncached.Get works when calling the invoker from a controller, but not when calling from the API.

This change also includes some generated changes that were left out of a previous change.

Issue: https://github.com/otto8-ai/otto8/issues/670