### PR TITLE
fix: wait for the alias to be processed in the API layer

### DIFF
--- a/pkg/controller/handlers/alias/alias.go
+++ b/pkg/controller/handlers/alias/alias.go
@@ -27,8 +27,9 @@ func AssignAlias(req router.Request, _ router.Response) error {
 	aliasable := req.Object.(v1.Aliasable)
 
 	if aliasable.GetAliasName() == "" {
-		if aliasable.IsAssigned() {
+		if aliasable.IsAssigned() || aliasable.GetGeneration() != aliasable.GetAliasObservedGeneration() {
 			aliasable.SetAssigned(false)
+			aliasable.SetAliasObservedGeneration(aliasable.GetGeneration())
 			return req.Client.Status().Update(req.Ctx, req.Object)
 		}
 
@@ -60,8 +61,9 @@ func AssignAlias(req router.Request, _ router.Response) error {
 		return err
 	}
 
-	if assigned := matches(alias, req.Object); assigned != aliasable.IsAssigned() {
+	if assigned := matches(alias, req.Object); assigned != aliasable.IsAssigned() || aliasable.GetGeneration() != aliasable.GetAliasObservedGeneration() {
 		aliasable.SetAssigned(assigned)
+		aliasable.SetAliasObservedGeneration(aliasable.GetGeneration())
 		return req.Client.Status().Update(req.Ctx, req.Object)
 	}
 

--- a/pkg/storage/apis/otto.otto8.ai/v1/agent.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/agent.go
@@ -36,6 +36,14 @@ func (a *Agent) SetAssigned(assigned bool) {
 	a.Status.AliasAssigned = assigned
 }
 
+func (a *Agent) GetAliasObservedGeneration() int64 {
+	return a.Status.AliasObservedGeneration
+}
+
+func (a *Agent) SetAliasObservedGeneration(gen int64) {
+	a.Status.AliasObservedGeneration = gen
+}
+
 func (a *Agent) Has(field string) bool {
 	return a.Get(field) != ""
 }
@@ -64,10 +72,11 @@ type AgentSpec struct {
 }
 
 type AgentStatus struct {
-	KnowledgeSetNames []string                                 `json:"knowledgeSetNames,omitempty"`
-	WorkspaceName     string                                   `json:"workspaceName,omitempty"`
-	AliasAssigned     bool                                     `json:"aliasAssigned,omitempty"`
-	AuthStatus        map[string]types.OAuthAppLoginAuthStatus `json:"authStatus,omitempty"`
+	KnowledgeSetNames       []string                                 `json:"knowledgeSetNames,omitempty"`
+	WorkspaceName           string                                   `json:"workspaceName,omitempty"`
+	AliasAssigned           bool                                     `json:"aliasAssigned,omitempty"`
+	AuthStatus              map[string]types.OAuthAppLoginAuthStatus `json:"authStatus,omitempty"`
+	AliasObservedGeneration int64                                    `json:"aliasProcessed,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/storage/apis/otto.otto8.ai/v1/alias.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/alias.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -42,9 +43,12 @@ type AliasSpec struct {
 // +k8s:deepcopy-gen=false
 
 type Aliasable interface {
+	kclient.Object
 	GetAliasName() string
 	SetAssigned(bool)
 	IsAssigned() bool
+	GetAliasObservedGeneration() int64
+	SetAliasObservedGeneration(int64)
 }
 
 // +k8s:deepcopy-gen=false

--- a/pkg/storage/apis/otto.otto8.ai/v1/defaultmodelalias.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/defaultmodelalias.go
@@ -29,6 +29,12 @@ func (a *DefaultModelAlias) GetAliasScope() string {
 	return "Model"
 }
 
+func (a *DefaultModelAlias) GetAliasObservedGeneration() int64 {
+	return a.Generation
+}
+
+func (a *DefaultModelAlias) SetAliasObservedGeneration(int64) {}
+
 type DefaultModelAliasSpec struct {
 	Manifest types.DefaultModelAliasManifest `json:"manifest"`
 }

--- a/pkg/storage/apis/otto.otto8.ai/v1/emailaddress.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/emailaddress.go
@@ -32,6 +32,14 @@ func (in *EmailReceiver) IsAssigned() bool {
 	return in.Status.AliasAssigned
 }
 
+func (in *EmailReceiver) GetAliasObservedGeneration() int64 {
+	return in.Status.AliasObservedGeneration
+}
+
+func (in *EmailReceiver) SetAliasObservedGeneration(gen int64) {
+	in.Status.AliasObservedGeneration = gen
+}
+
 func (*EmailReceiver) GetColumns() [][]string {
 	return [][]string{
 		{"Name", "Name"},
@@ -42,10 +50,10 @@ func (*EmailReceiver) GetColumns() [][]string {
 	}
 }
 
-func (w *EmailReceiver) DeleteRefs() []Ref {
-	if system.IsWorkflowID(w.Spec.Workflow) {
+func (in *EmailReceiver) DeleteRefs() []Ref {
+	if system.IsWorkflowID(in.Spec.Workflow) {
 		return []Ref{
-			{ObjType: new(Workflow), Name: w.Spec.Workflow},
+			{ObjType: new(Workflow), Name: in.Spec.Workflow},
 		}
 	}
 	return nil
@@ -56,7 +64,8 @@ type EmailReceiverSpec struct {
 }
 
 type EmailReceiverStatus struct {
-	AliasAssigned bool `json:"aliasAssigned,omitempty"`
+	AliasAssigned           bool  `json:"aliasAssigned,omitempty"`
+	AliasObservedGeneration int64 `json:"aliasProcessed,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/storage/apis/otto.otto8.ai/v1/model.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/model.go
@@ -26,12 +26,21 @@ func (m *Model) SetAssigned(assigned bool) {
 	m.Status.AliasAssigned = assigned
 }
 
+func (m *Model) GetAliasObservedGeneration() int64 {
+	return m.Status.AliasObservedGeneration
+}
+
+func (m *Model) SetAliasObservedGeneration(gen int64) {
+	m.Status.AliasObservedGeneration = gen
+}
+
 type ModelSpec struct {
 	Manifest types.ModelManifest `json:"manifest,omitempty"`
 }
 
 type ModelStatus struct {
-	AliasAssigned bool `json:"aliasAssigned,omitempty"`
+	AliasAssigned           bool  `json:"aliasAssigned,omitempty"`
+	AliasObservedGeneration int64 `json:"aliasProcessed,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/storage/apis/otto.otto8.ai/v1/oauthapp.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/oauthapp.go
@@ -28,12 +28,17 @@ func (r *OAuthApp) GetAliasName() string {
 	return r.Spec.Manifest.Integration
 }
 
-func (r *OAuthApp) SetAssigned(bool) {
-}
+func (r *OAuthApp) SetAssigned(bool) {}
 
 func (r *OAuthApp) IsAssigned() bool {
 	return true
 }
+
+func (r *OAuthApp) GetAliasObservedGeneration() int64 {
+	return r.Generation
+}
+
+func (r *OAuthApp) SetAliasObservedGeneration(int64) {}
 
 func (r *OAuthApp) Has(field string) bool {
 	return r.Get(field) != ""

--- a/pkg/storage/apis/otto.otto8.ai/v1/webhook.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/webhook.go
@@ -32,6 +32,14 @@ func (w *Webhook) IsAssigned() bool {
 	return w.Status.AliasAssigned
 }
 
+func (w *Webhook) GetAliasObservedGeneration() int64 {
+	return w.Status.AliasObservedGeneration
+}
+
+func (w *Webhook) SetAliasObservedGeneration(gen int64) {
+	w.Status.AliasObservedGeneration = gen
+}
+
 func (*Webhook) GetColumns() [][]string {
 	return [][]string{
 		{"Name", "Name"},
@@ -60,6 +68,7 @@ type WebhookSpec struct {
 type WebhookStatus struct {
 	AliasAssigned              bool         `json:"aliasAssigned,omitempty"`
 	LastSuccessfulRunCompleted *metav1.Time `json:"lastSuccessfulRunCompleted,omitempty"`
+	AliasObservedGeneration    int64        `json:"aliasProcessed,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/storage/apis/otto.otto8.ai/v1/workflow.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/workflow.go
@@ -61,6 +61,14 @@ func (in *Workflow) GetAliasScope() string {
 	return "Agent"
 }
 
+func (in *Workflow) GetAliasObservedGeneration() int64 {
+	return in.Status.AliasObservedGeneration
+}
+
+func (in *Workflow) SetAliasObservedGeneration(gen int64) {
+	in.Status.AliasObservedGeneration = gen
+}
+
 type WorkflowSpec struct {
 	AgentName string                 `json:"agentName,omitempty"`
 	UserID    string                 `json:"userID,omitempty"`
@@ -68,10 +76,11 @@ type WorkflowSpec struct {
 }
 
 type WorkflowStatus struct {
-	WorkspaceName     string                                   `json:"workspaceName,omitempty"`
-	KnowledgeSetNames []string                                 `json:"knowledgeSetNames,omitempty"`
-	AliasAssigned     bool                                     `json:"aliasAssigned,omitempty"`
-	AuthStatus        map[string]types.OAuthAppLoginAuthStatus `json:"authStatus,omitempty"`
+	WorkspaceName           string                                   `json:"workspaceName,omitempty"`
+	KnowledgeSetNames       []string                                 `json:"knowledgeSetNames,omitempty"`
+	AliasAssigned           bool                                     `json:"aliasAssigned,omitempty"`
+	AuthStatus              map[string]types.OAuthAppLoginAuthStatus `json:"authStatus,omitempty"`
+	AliasObservedGeneration int64                                    `json:"aliasProcessed,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -4047,6 +4047,12 @@ func schema_storage_apis_ottootto8ai_v1_AgentStatus(ref common.ReferenceCallback
 							},
 						},
 					},
+					"aliasProcessed": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
 				},
 			},
 		},
@@ -4633,6 +4639,12 @@ func schema_storage_apis_ottootto8ai_v1_EmailReceiverStatus(ref common.Reference
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",
+						},
+					},
+					"aliasProcessed": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 				},
@@ -5421,6 +5433,12 @@ func schema_storage_apis_ottootto8ai_v1_ModelStatus(ref common.ReferenceCallback
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",
+						},
+					},
+					"aliasProcessed": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 				},
@@ -6877,6 +6895,12 @@ func schema_storage_apis_ottootto8ai_v1_WebhookStatus(ref common.ReferenceCallba
 							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"aliasProcessed": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
 				},
 			},
 		},
@@ -7281,6 +7305,12 @@ func schema_storage_apis_ottootto8ai_v1_WorkflowStatus(ref common.ReferenceCallb
 									},
 								},
 							},
+						},
+					},
+					"aliasProcessed": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 				},

--- a/pkg/wait/waitfor.go
+++ b/pkg/wait/waitfor.go
@@ -34,18 +34,20 @@ func load(ctx context.Context, c kclient.Client, obj kclient.Object, create bool
 		return nil
 	}
 
-	err := c.Get(ctx, kclient.ObjectKeyFromObject(obj), obj)
-	if err == nil {
-		return nil
-	} else if err := kclient.IgnoreNotFound(err); err != nil {
-		return err
+	if obj.GetName() != "" {
+		err := c.Get(ctx, kclient.ObjectKeyFromObject(obj), obj)
+		if err == nil {
+			return nil
+		} else if err := kclient.IgnoreNotFound(err); err != nil {
+			return err
+		}
+
+		if !create {
+			return err
+		}
 	}
 
-	if !create {
-		return err
-	}
-
-	err = c.Create(ctx, obj)
+	err := c.Create(ctx, obj)
 	if err == nil {
 		return nil
 	} else if apierrors.IsAlreadyExists(err) {


### PR DESCRIPTION
For objects with aliases, like agents, if the alias is created or updated, the API may return stale data because the controller hasn't processed the object yet. This change adds a mechanism for the API layer to ensure that the alias controller has processed the object.

Issue: https://github.com/otto8-ai/otto8/issues/634