### PR TITLE
fix: unable to start a new thread when tool call in progress

### DIFF
--- a/ui/admin/app/components/agent/Agent.tsx
+++ b/ui/admin/app/components/agent/Agent.tsx
@@ -17,7 +17,6 @@ import { ScrollArea } from "~/components/ui/scroll-area";
 import { useDebounce } from "~/hooks/useDebounce";
 
 type AgentProps = {
-    agent: AgentType;
     className?: string;
     onRefresh?: (threadId: string | null) => void;
 };

--- a/ui/admin/app/components/chat/ChatContext.tsx
+++ b/ui/admin/app/components/chat/ChatContext.tsx
@@ -205,6 +205,7 @@ function useMessageSource(threadId?: Nullish<string>) {
 
         return () => {
             source.close();
+            setIsRunning(false);
         };
     }, [threadId, addContent]);
 

--- a/ui/admin/app/routes/_auth.agents.$agent.tsx
+++ b/ui/admin/app/routes/_auth.agents.$agent.tsx
@@ -68,11 +68,7 @@ export default function ChatAgent() {
             <ResizablePanelGroup direction="horizontal" className="flex-auto">
                 <ResizablePanel className="">
                     <AgentProvider agent={agent}>
-                        <Agent
-                            agent={agent}
-                            onRefresh={updateThreadId}
-                            key={agent.id}
-                        />
+                        <Agent onRefresh={updateThreadId} key={agent.id} />
                     </AgentProvider>
                 </ResizablePanel>
                 <ResizableHandle withHandle />

--- a/ui/admin/app/routes/_auth.agents.$agent.tsx
+++ b/ui/admin/app/routes/_auth.agents.$agent.tsx
@@ -65,30 +65,27 @@ export default function ChatAgent() {
 
     return (
         <div className="h-full flex flex-col overflow-hidden relative">
-            <ChatProvider
-                id={agent.id}
-                threadId={threadId}
-                onCreateThreadId={updateThreadId}
-            >
-                <AgentProvider agent={agent}>
-                    <ResizablePanelGroup
-                        direction="horizontal"
-                        className="flex-auto"
+            <ResizablePanelGroup direction="horizontal" className="flex-auto">
+                <ResizablePanel className="">
+                    <AgentProvider agent={agent}>
+                        <Agent
+                            agent={agent}
+                            onRefresh={updateThreadId}
+                            key={agent.id}
+                        />
+                    </AgentProvider>
+                </ResizablePanel>
+                <ResizableHandle withHandle />
+                <ResizablePanel>
+                    <ChatProvider
+                        id={agent.id}
+                        threadId={threadId}
+                        onCreateThreadId={updateThreadId}
                     >
-                        <ResizablePanel className="">
-                            <Agent
-                                agent={agent}
-                                onRefresh={updateThreadId}
-                                key={agent.id}
-                            />
-                        </ResizablePanel>
-                        <ResizableHandle withHandle />
-                        <ResizablePanel>
-                            <Chat className="bg-sidebar" />
-                        </ResizablePanel>
-                    </ResizablePanelGroup>
-                </AgentProvider>
-            </ChatProvider>
+                        <Chat className="bg-sidebar" />
+                    </ChatProvider>
+                </ResizablePanel>
+            </ResizablePanelGroup>
         </div>
     );
 }


### PR DESCRIPTION
Addresses #509
- wraps components only with necessary context providers
- internally indicates chat is no longer running when switching threads

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>