### PR TITLE
fix: show modelProvider in agent's model dropdown

### DIFF
--- a/ui/admin/app/components/agent/AgentForm.tsx
+++ b/ui/admin/app/components/agent/AgentForm.tsx
@@ -137,7 +137,10 @@ export function AgentForm({ agent, onSubmit, onChange }: AgentFormProps) {
 
                                 {models.map((m) => (
                                     <SelectItem key={m.id} value={m.id}>
-                                        {m.name || m.id}
+                                        {m.name || m.id}{" "}
+                                        <span className="text-muted-foreground">
+                                            ({m.modelProvider})
+                                        </span>
                                     </SelectItem>
                                 ))}
                             </SelectContent>


### PR DESCRIPTION
Quick fix to display `modelProvider` in the model dropdown when selecting a model for an agent.

Note: Added quick question about the `modelProvider` in the related issue: #613 

<img width="486" alt="Screenshot 2024-11-26 at 4 27 44 PM" src="https://github.com/user-attachments/assets/e767c0e4-2ef5-4dd7-aa21-238de2adb36e">
