### PR TITLE
feat: add available models API

### DIFF
--- a/docs/docs/05-configuration/02-model-providers.md
+++ b/docs/docs/05-configuration/02-model-providers.md
@@ -61,6 +61,27 @@ The OpenAI model provider is the default and is configured by either setting `OP
 The Azure OpenAI model provider requires setting the following environment variables:
 - `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_API_KEY`: Found on the "Home" page of the Azure OpenAI Studio.
 - `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT`:  The endpoint to use, found by clicking on the "Deployment" name from the "Deployments" page of the Azure OpenAI Studio.
+- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_ID`: The resource group name for the Azure OpenAI resource, found by click on the resource name in the top-right of the Azure OpenAI Studio.
+
+The remainder of these environment variables are used to list the available deployments in Azure. A service principal must be created with read permission to the `Microsoft.CognitiveServices`. At the time of this writing, a built-in role doesn't exist in Azure. One can be created with the following permissions:
+```json
+"permissions": [
+	{
+		"actions": [
+			"Microsoft.CognitiveServices/*/read"
+		], 
+		"notActions": [],
+		"dataActions": [],
+		"notDataActions": []
+	}
+]
+```
+
+After this service principal is created, the following environment variables are required to configure the model provider in Otto8:
+- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_ID`: The client ID for the app registration.
+- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_SECRET`: The client secret for the app registration.
+- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_TENANT_ID`: The tenant ID for the app registration.
+- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_SUBSCRIPTION_ID`: The subscription ID for the Azure account.
 
 :::note
 When configuring models with the Azure OpenAI provider in Otto8, the "Target Model" should be the "Deployment" from Azure.

--- a/docs/docs/05-configuration/02-model-providers.md
+++ b/docs/docs/05-configuration/02-model-providers.md
@@ -61,7 +61,7 @@ The OpenAI model provider is the default and is configured by either setting `OP
 The Azure OpenAI model provider requires setting the following environment variables:
 - `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_API_KEY`: Found on the "Home" page of the Azure OpenAI Studio.
 - `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT`:  The endpoint to use, found by clicking on the "Deployment" name from the "Deployments" page of the Azure OpenAI Studio.
-- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_ID`: The resource group name for the Azure OpenAI resource, found by click on the resource name in the top-right of the Azure OpenAI Studio.
+- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_ID`: The resource group name for the Azure OpenAI resource, found by clicking on the resource name in the top-right of the Azure OpenAI Studio.
 
 The remainder of these environment variables are used to list the available deployments in Azure. A service principal must be created with read permission to the `Microsoft.CognitiveServices`. At the time of this writing, a built-in role doesn't exist in Azure. One can be created with the following permissions:
 ```json

--- a/docs/docs/05-configuration/02-model-providers.md
+++ b/docs/docs/05-configuration/02-model-providers.md
@@ -9,7 +9,7 @@ Below is a summary of the configuration options for each provider. However, the 
   "id": "azure-openai-model-provider",
   "created": "2024-11-08T16:03:21-05:00",
   "metadata": {
-    "envVars": "OTTO8_AZURE_OPENAI_MODEL_PROVIDER_API_KEY,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_DEPLOYMENT_NAME"
+    "envVars": "OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_SECRET,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_TENANT_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_SUBSCRIPTION_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_GROUP"
   },
   "name": "Azure OpenAI Provider",
   "toolType": "modelProvider",
@@ -19,9 +19,12 @@ Below is a summary of the configuration options for each provider. However, the 
   "description": "Model provider for Azure OpenAI hosted models",
   "modelProviderStatus": {
     "missingEnvVars": [
-      "OTTO8_AZURE_OPENAI_MODEL_PROVIDER_API_KEY",
-      "OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT",
-      "OTTO8_AZURE_OPENAI_MODEL_PROVIDER_DEPLOYMENT_NAME"
+		"OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT",
+		"OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_ID",
+		"OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_SECRET",
+		"OTTO8_AZURE_OPENAI_MODEL_PROVIDER_TENANT_ID",
+		"OTTO8_AZURE_OPENAI_MODEL_PROVIDER_SUBSCRIPTION_ID",
+		"OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_GROUP"
     ],  
     "configured": false
   }
@@ -36,7 +39,7 @@ Once all the required environment variables are set, then the API would return s
   "id": "azure-openai-model-provider",
   "created": "2024-11-08T16:03:21-05:00",
   "metadata": {
-    "envVars": "OTTO8_AZURE_OPENAI_MODEL_PROVIDER_API_KEY,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_DEPLOYMENT_NAME"
+    "envVars": "OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_SECRET,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_TENANT_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_SUBSCRIPTION_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_GROUP"
   },
   "name": "Azure OpenAI Provider",
   "toolType": "modelProvider",
@@ -59,7 +62,7 @@ The OpenAI model provider is the default and is configured by either setting `OP
 ## Azure OpenAI
 
 The Azure OpenAI model provider requires setting the following environment variables:
-- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT`:  The endpoint to use, found by clicking on the "Deployment" name from the "Deployments" page of the Azure OpenAI Studio.
+- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT`:  The endpoint to use, found by clicking on the "Deployment" name from the "Deployments" page of the Azure OpenAI Studio. The provider endpoint must be in the format `https://<your-custom-name>.openai.azure.com` - if your Azure OpenAI resource doesn't have an endpoint that looks like this, you need to create one.
 - `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_GROUP`: The resource group name for the Azure OpenAI resource, found by clicking on the resource name in the top-right of the Azure OpenAI Studio.
 
 A service principal must be created with the (equivalent permissions of the) `Cognitive Services OpenAI User`.  After this service principal is created, the following environment variables configure the model provider in Otto8:

--- a/docs/docs/05-configuration/02-model-providers.md
+++ b/docs/docs/05-configuration/02-model-providers.md
@@ -59,29 +59,15 @@ The OpenAI model provider is the default and is configured by either setting `OP
 ## Azure OpenAI
 
 The Azure OpenAI model provider requires setting the following environment variables:
-- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_API_KEY`: Found on the "Home" page of the Azure OpenAI Studio.
 - `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT`:  The endpoint to use, found by clicking on the "Deployment" name from the "Deployments" page of the Azure OpenAI Studio.
-- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_ID`: The resource group name for the Azure OpenAI resource, found by clicking on the resource name in the top-right of the Azure OpenAI Studio.
+- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_GROUP`: The resource group name for the Azure OpenAI resource, found by clicking on the resource name in the top-right of the Azure OpenAI Studio.
 
-The remainder of these environment variables are used to list the available deployments in Azure. A service principal must be created with read permission to the `Microsoft.CognitiveServices`. At the time of this writing, a built-in role doesn't exist in Azure. One can be created with the following permissions:
-```json
-"permissions": [
-	{
-		"actions": [
-			"Microsoft.CognitiveServices/*/read"
-		], 
-		"notActions": [],
-		"dataActions": [],
-		"notDataActions": []
-	}
-]
-```
-
-After this service principal is created, the following environment variables are required to configure the model provider in Otto8:
+A service principal must be created with the (equivalent permissions of the) `Cognitive Services OpenAI User`.  After this service principal is created, the following environment variables configure the model provider in Otto8:
 - `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_ID`: The client ID for the app registration.
 - `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_SECRET`: The client secret for the app registration.
 - `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_TENANT_ID`: The tenant ID for the app registration.
 - `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_SUBSCRIPTION_ID`: The subscription ID for the Azure account.
+- `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_API_VERSION`: (optional) Specify the API version to use with Azure OpenAI instead of `2024-10-21`.
 
 :::note
 When configuring models with the Azure OpenAI provider in Otto8, the "Target Model" should be the "Deployment" from Azure.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
+	github.com/gptscript-ai/chat-completion-client v0.0.0-20241127005108-02b41e1cd02e
 	github.com/gptscript-ai/cmd v0.0.0-20240907001148-ffd49061124a
 	github.com/gptscript-ai/go-gptscript v0.9.6-0.20241115201052-7efb3409cfcc
 	github.com/gptscript-ai/gptscript v0.9.6-0.20241121180135-e5fe428c6858
@@ -138,7 +139,6 @@ require (
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gptscript-ai/broadcaster v0.0.0-20240625175512-c43682019b86 // indirect
-	github.com/gptscript-ai/chat-completion-client v0.0.0-20241104122544-5fe75f07c131 // indirect
 	github.com/gptscript-ai/tui v0.0.0-20240923192013-172e51ccf1d6 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gptscript-ai/broadcaster v0.0.0-20240625175512-c43682019b86 h1:m9yLtIEd0z1ia8qFjq3u0Ozb6QKwidyL856JLJp6nbA=
 github.com/gptscript-ai/broadcaster v0.0.0-20240625175512-c43682019b86/go.mod h1:lK3K5EZx4dyT24UG3yCt0wmspkYqrj4D/8kxdN3relk=
-github.com/gptscript-ai/chat-completion-client v0.0.0-20241104122544-5fe75f07c131 h1:y2FcmT4X8U606gUS0teX5+JWX9K/NclsLEhHiyrd+EU=
-github.com/gptscript-ai/chat-completion-client v0.0.0-20241104122544-5fe75f07c131/go.mod h1:7P/o6/IWa1KqsntVf68hSnLKuu3+xuqm6lYhch1w4jo=
+github.com/gptscript-ai/chat-completion-client v0.0.0-20241127005108-02b41e1cd02e h1:Nj9709xPbjAPLOsdR/Ik4zaJfpU4O6AEP/R6o9h30CE=
+github.com/gptscript-ai/chat-completion-client v0.0.0-20241127005108-02b41e1cd02e/go.mod h1:7P/o6/IWa1KqsntVf68hSnLKuu3+xuqm6lYhch1w4jo=
 github.com/gptscript-ai/cmd v0.0.0-20240907001148-ffd49061124a h1:LX7AOcbBoTnUk/233EARaZMnyQO66yXM9lyigniich4=
 github.com/gptscript-ai/cmd v0.0.0-20240907001148-ffd49061124a/go.mod h1:DJAo1xTht1LDkNYFNydVjTHd576TC7MlpsVRl3oloVw=
 github.com/gptscript-ai/go-gptscript v0.9.6-0.20241115201052-7efb3409cfcc h1:D0N65peenVgPor9Ph0LiMLfgI4qCE9VGxgw8KxlvLgE=

--- a/pkg/api/handlers/availablemodels.go
+++ b/pkg/api/handlers/availablemodels.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	openai "github.com/gptscript-ai/chat-completion-client"
+	"github.com/otto8-ai/otto8/apiclient/types"
+	"github.com/otto8-ai/otto8/pkg/api"
+	"github.com/otto8-ai/otto8/pkg/gateway/server/dispatcher"
+	"github.com/otto8-ai/otto8/pkg/storage/apis/otto.otto8.ai/v1"
+	"github.com/otto8-ai/otto8/pkg/system"
+	"k8s.io/apimachinery/pkg/fields"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type AvailableModelsHandler struct {
+	dispatcher *dispatcher.Dispatcher
+}
+
+func NewAvailableModelsHandler(dispatcher *dispatcher.Dispatcher) *AvailableModelsHandler {
+	return &AvailableModelsHandler{
+		dispatcher: dispatcher,
+	}
+}
+
+func (a *AvailableModelsHandler) List(req api.Context) error {
+	var modelProviderReference v1.ToolReferenceList
+	if err := req.List(&modelProviderReference, &kclient.ListOptions{
+		Namespace: req.Namespace(),
+		FieldSelector: fields.SelectorFromSet(map[string]string{
+			"spec.type": string(types.ToolReferenceTypeModelProvider),
+		}),
+	}); err != nil {
+		return err
+	}
+
+	var oModels openai.ModelsList
+	for _, modelProvider := range modelProviderReference.Items {
+		if convertedModelProvider := convertModelProviderToolRef(modelProvider); !convertedModelProvider.Configured || modelProvider.Name == system.ModelProviderTool {
+			continue
+		}
+
+		m, err := a.getAvailableModelsForProvider(req.Context(), modelProvider.Namespace, modelProvider.Name)
+		if err != nil {
+			return err
+		}
+
+		for _, model := range m.Models {
+			if model.Metadata == nil {
+				model.Metadata = make(map[string]string)
+			}
+			model.Metadata["model-provider"] = modelProvider.Name
+			oModels.Models = append(oModels.Models, model)
+		}
+	}
+
+	return req.Write(oModels)
+}
+
+func (a *AvailableModelsHandler) ListForModelProvider(req api.Context) error {
+	var modelProviderReference v1.ToolReference
+	if err := req.Get(&modelProviderReference, req.PathValue("model_provider")); err != nil {
+		return err
+	}
+
+	if modelProviderReference.Spec.Type != types.ToolReferenceTypeModelProvider {
+		return types.NewErrBadRequest("%s is not a model provider", modelProviderReference.Name)
+	}
+
+	if modelProvider := convertModelProviderToolRef(modelProviderReference); !modelProvider.Configured {
+		return types.NewErrBadRequest("model provider %s is not configured, missing env vars: %s", modelProviderReference.Name, strings.Join(modelProvider.MissingEnvVars, ", "))
+	}
+
+	oModels, err := a.getAvailableModelsForProvider(req.Context(), modelProviderReference.Namespace, modelProviderReference.Name)
+	if err != nil {
+		return err
+	}
+
+	return req.Write(oModels)
+}
+
+func (a *AvailableModelsHandler) getAvailableModelsForProvider(ctx context.Context, modelProviderNamespace, modelProviderName string) (*openai.ModelsList, error) {
+	u, err := a.dispatcher.URLForModelProvider(ctx, modelProviderNamespace, modelProviderName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get URL for model provider: %w", err)
+	}
+
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String()+"/v1/models", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request to model provider %s: %w", modelProviderName, err)
+	}
+
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request to model provider %s: %w", modelProviderName, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		message, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to get model list from model provider %s: %s", modelProviderName, message)
+	}
+
+	var oModels openai.ModelsList
+	if err = json.NewDecoder(resp.Body).Decode(&oModels); err != nil {
+		return nil, fmt.Errorf("failed to decode model list from model provider %s: %w", modelProviderName, err)
+	}
+
+	return &oModels, nil
+}

--- a/pkg/api/handlers/availablemodels.go
+++ b/pkg/api/handlers/availablemodels.go
@@ -87,7 +87,7 @@ func (a *AvailableModelsHandler) ListForModelProvider(req api.Context) error {
 func (a *AvailableModelsHandler) getAvailableModelsForProvider(ctx context.Context, modelProviderNamespace, modelProviderName string) (*openai.ModelsList, error) {
 	u, err := a.dispatcher.URLForModelProvider(ctx, modelProviderNamespace, modelProviderName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get URL for model provider: %w", err)
+		return nil, fmt.Errorf("failed to get URL for model provider %q: %w", modelProviderName, err)
 	}
 
 	r, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String()+"/v1/models", nil)

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -22,6 +22,7 @@ func Router(services *services.Services) (http.Handler, error) {
 	webhooks := handlers.NewWebhookHandler()
 	cronJobs := handlers.NewCronJobHandler()
 	models := handlers.NewModelHandler()
+	availableModels := handlers.NewAvailableModelsHandler(services.ModelProviderDispatcher)
 	prompt := handlers.NewPromptHandler(services.GPTClient)
 	emailreceiver := handlers.NewEmailReceiverHandler(services.EmailServerName)
 	defaultModelAliases := handlers.NewDefaultModelAliasHandler()
@@ -225,6 +226,10 @@ func Router(services *services.Services) (http.Handler, error) {
 	mux.HandleFunc("DELETE /api/models/{id}", models.Delete)
 	mux.HandleFunc("GET /api/models", models.List)
 	mux.HandleFunc("GET /api/models/{id}", models.ByID)
+
+	// Available Models
+	mux.HandleFunc("GET /api/available-models", availableModels.List)
+	mux.HandleFunc("GET /api/available-models/{model_provider}", availableModels.ListForModelProvider)
 
 	// Default Model Aliases
 	mux.HandleFunc("GET /api/default-model-aliases", defaultModelAliases.List)

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -24,21 +23,44 @@ import (
 )
 
 type Dispatcher struct {
-	openAIAPIKey string
-	invoker      *invoke.Invoker
-	client       kclient.Client
-	lock         *sync.RWMutex
-	urls         map[string]*url.URL
+	invoker *invoke.Invoker
+	client  kclient.Client
+	lock    *sync.RWMutex
+	urls    map[string]*url.URL
 }
 
 func New(invoker *invoke.Invoker, c kclient.Client) *Dispatcher {
 	return &Dispatcher{
-		openAIAPIKey: os.Getenv("OTTO8_OPENAI_MODEL_PROVIDER_API_KEY"),
-		invoker:      invoker,
-		client:       c,
-		lock:         new(sync.RWMutex),
-		urls:         make(map[string]*url.URL),
+		invoker: invoker,
+		client:  c,
+		lock:    new(sync.RWMutex),
+		urls:    make(map[string]*url.URL),
 	}
+}
+
+func (d *Dispatcher) URLForModelProvider(ctx context.Context, namespace, modelProviderName string) (*url.URL, error) {
+	d.lock.RLock()
+	u, ok := d.urls[modelProviderName]
+	d.lock.RUnlock()
+	if ok && (u.Scheme == "https" || engine.IsDaemonRunning(u.String())) {
+		return u, nil
+	}
+
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	u, ok = d.urls[modelProviderName]
+	if ok && (u.Scheme == "https" || engine.IsDaemonRunning(u.String())) {
+		return u, nil
+	}
+
+	u, err := d.startModelProvider(ctx, namespace, modelProviderName)
+	if err != nil {
+		return nil, err
+	}
+
+	d.urls[modelProviderName] = u
+	return u, nil
 }
 
 func (d *Dispatcher) TransformRequest(req *http.Request, namespace string) error {
@@ -57,27 +79,11 @@ func (d *Dispatcher) TransformRequest(req *http.Request, namespace string) error
 		return fmt.Errorf("failed to get model: %w", err)
 	}
 
-	d.lock.RLock()
-	u, ok := d.urls[model.Spec.Manifest.ModelProvider]
-	d.lock.RUnlock()
-	if ok && (u.Scheme == "https" || engine.IsDaemonRunning(u.String())) {
-		return d.transformRequest(req, *u, body, model.Spec.Manifest.TargetModel)
-	}
-
-	d.lock.Lock()
-	defer d.lock.Unlock()
-
-	u, ok = d.urls[model.Spec.Manifest.ModelProvider]
-	if ok && (u.Scheme == "https" || engine.IsDaemonRunning(u.String())) {
-		return d.transformRequest(req, *u, body, model.Spec.Manifest.TargetModel)
-	}
-
-	u, err = d.startModelProvider(req.Context(), model)
+	u, err := d.URLForModelProvider(req.Context(), namespace, model.Spec.Manifest.ModelProvider)
 	if err != nil {
-		return fmt.Errorf("failed to start model provider: %w", err)
+		return fmt.Errorf("failed to get model provider: %w", err)
 	}
 
-	d.urls[model.Spec.Manifest.ModelProvider] = u
 	return d.transformRequest(req, *u, body, model.Spec.Manifest.TargetModel)
 }
 
@@ -101,11 +107,11 @@ func (d *Dispatcher) getModelProviderForModel(ctx context.Context, namespace, mo
 	return nil, fmt.Errorf("model %q not found", model)
 }
 
-func (d *Dispatcher) startModelProvider(ctx context.Context, model *v1.Model) (*url.URL, error) {
+func (d *Dispatcher) startModelProvider(ctx context.Context, namespace, modelProviderName string) (*url.URL, error) {
 	thread := &v1.Thread{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.ThreadPrefix + model.Name,
-			Namespace: model.Namespace,
+			Name:      system.ThreadPrefix + modelProviderName,
+			Namespace: namespace,
 		},
 		Spec: v1.ThreadSpec{
 			SystemTask: true,
@@ -120,7 +126,7 @@ func (d *Dispatcher) startModelProvider(ctx context.Context, model *v1.Model) (*
 		return nil, fmt.Errorf("failed to get thread: %w", err)
 	}
 
-	task, err := d.invoker.SystemTask(ctx, thread, model.Spec.Manifest.ModelProvider, "")
+	task, err := d.invoker.SystemTask(ctx, thread, modelProviderName, "")
 	if err != nil {
 		return nil, err
 	}
@@ -140,11 +146,6 @@ func (d *Dispatcher) transformRequest(req *http.Request, u url.URL, body map[str
 	u.Path = path.Join(u.Path, req.PathValue("path"))
 	req.URL = &u
 	req.Host = u.Host
-
-	// OpenAI is special, and we need to set the API key
-	if u.Host == "api.openai.com" {
-		req.Header.Set("Authorization", "Bearer "+d.openAIAPIKey)
-	}
 
 	body["model"] = targetModel
 	b, err := json.Marshal(body)

--- a/pkg/gateway/server/server.go
+++ b/pkg/gateway/server/server.go
@@ -12,10 +12,8 @@ import (
 	"github.com/otto8-ai/otto8/pkg/gateway/db"
 	"github.com/otto8-ai/otto8/pkg/gateway/server/dispatcher"
 	"github.com/otto8-ai/otto8/pkg/gateway/types"
-	"github.com/otto8-ai/otto8/pkg/invoke"
 	"github.com/otto8-ai/otto8/pkg/jwt"
 	"gorm.io/gorm"
-	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Options struct {
@@ -34,7 +32,7 @@ type Server struct {
 	modelDispatcher *dispatcher.Dispatcher
 }
 
-func New(ctx context.Context, db *db.DB, c kclient.Client, invoker *invoke.Invoker, tokenService *jwt.TokenService, adminEmails []string, opts Options) (*Server, error) {
+func New(ctx context.Context, db *db.DB, tokenService *jwt.TokenService, modelProviderDispatcher *dispatcher.Dispatcher, adminEmails []string, opts Options) (*Server, error) {
 	if err := db.AutoMigrate(); err != nil {
 		return nil, fmt.Errorf("auto migrate failed: %w", err)
 	}
@@ -52,7 +50,7 @@ func New(ctx context.Context, db *db.DB, c kclient.Client, invoker *invoke.Invok
 		httpClient:      &http.Client{},
 		client:          client.New(db, adminEmails),
 		tokenService:    tokenService,
-		modelDispatcher: dispatcher.New(invoker, c),
+		modelDispatcher: modelProviderDispatcher,
 	}
 
 	go s.autoCleanupTokens(ctx)

--- a/pkg/storage/apis/otto.otto8.ai/v1/toolreference.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/toolreference.go
@@ -1,8 +1,13 @@
 package v1
 
 import (
+	"github.com/otto8-ai/nah/pkg/fields"
 	"github.com/otto8-ai/otto8/apiclient/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	_ fields.Fields = (*ToolReference)(nil)
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -13,6 +18,25 @@ type ToolReference struct {
 
 	Spec   ToolReferenceSpec   `json:"spec,omitempty"`
 	Status ToolReferenceStatus `json:"status,omitempty"`
+}
+
+func (in *ToolReference) Has(field string) bool {
+	return in.Get(field) != ""
+}
+
+func (in *ToolReference) Get(field string) string {
+	if in != nil {
+		switch field {
+		case "spec.type":
+			return string(in.Spec.Type)
+		}
+	}
+
+	return ""
+}
+
+func (in *ToolReference) FieldNames() []string {
+	return []string{"spec.type"}
 }
 
 func (in *ToolReference) GetColumns() [][]string {


### PR DESCRIPTION
The available models API allows listing of all available models from all configured model providers in Otto8.

Requires: https://github.com/otto8-ai/tools/pull/248