### PR TITLE
fix: Prevent browser tab title from being set to "New Remix App"

### DIFF
--- a/ui/admin/app/routes/_index.tsx
+++ b/ui/admin/app/routes/_index.tsx
@@ -1,12 +1,5 @@
-import { type MetaFunction, redirect, useLoaderData } from "@remix-run/react";
+import { redirect, useLoaderData } from "@remix-run/react";
 import { $path } from "remix-routes";
-
-export const meta: MetaFunction = () => {
-    return [
-        { title: "New Remix App" },
-        { name: "description", content: "Welcome to Remix!" },
-    ];
-};
 
 export const clientLoader = async () => {
     throw redirect($path("/agents"));


### PR DESCRIPTION
Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>