### PR TITLE
Fix/admin/theme-consistency

### DIFF
--- a/ui/admin/app/components/agent/ToolForm.tsx
+++ b/ui/admin/app/components/agent/ToolForm.tsx
@@ -166,7 +166,7 @@ export function ToolForm({
                             onDelete={() => removeTools([field.tool])}
                             actions={
                                 <Tooltip>
-                                    <TooltipTrigger asChild>
+                                    <TooltipTrigger>
                                         <Switch
                                             checked={
                                                 field.variant ===

--- a/ui/admin/app/tailwind.css
+++ b/ui/admin/app/tailwind.css
@@ -94,8 +94,8 @@ body {
 
         /* Start theme colors (Not accessible by Tailwind) */
 
-        --main-surface-primary: 223 20% 10%;
-        --main-surface-secondary: 223 20% 5%;
+        --main-surface-secondary: 223 20% 10%;
+        --main-surface-primary: 223 20% 5%;
 
         --accent-surface-primary: 223 5% 15%;
         --accent-surface-secondary: 223 87% 25%;


### PR DESCRIPTION
Previously:

Light mode: primary bg color was near true white and secondary bg color was slightly muted

Dark mode: primary bg color was slightly muted and secondary bg color was near true black

This created inconsistency in how things contrasted in light mode vs dark mode. This has been rectified by swapping the primary/secondary surface colors in the theme

Before:
<img width="1796" alt="Screenshot 2024-11-27 at 8 58 53 AM" src="https://github.com/user-attachments/assets/c5c12d77-af97-4cb3-8288-2217a1e552fc">

After:
<img width="1840" alt="Screenshot 2024-11-27 at 8 58 15 AM" src="https://github.com/user-attachments/assets/499e2320-2901-42f0-a03f-babd6eb4683d">
