### PR TITLE
Fix: fix fe code to not make requests when validating cache

### DIFF
--- a/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
+++ b/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
@@ -97,7 +97,7 @@ export default function AgentKnowledgePanel({
             ),
         {
             revalidateOnFocus: false,
-            refreshInterval: blockPollingLocalFiles ? undefined : 1000,
+            refreshInterval: blockPollingLocalFiles ? undefined : 5000,
         }
     );
     const localFiles = useMemo(
@@ -110,7 +110,7 @@ export default function AgentKnowledgePanel({
         ({ agentId }) => KnowledgeService.getKnowledgeSourcesForAgent(agentId),
         {
             revalidateOnFocus: false,
-            refreshInterval: blockPollingSources ? undefined : 1000,
+            refreshInterval: blockPollingSources ? undefined : 5000,
         }
     );
     const knowledgeSources = useMemo(

--- a/ui/admin/app/components/knowledge/KnowledgeSourceDetail.tsx
+++ b/ui/admin/app/components/knowledge/KnowledgeSourceDetail.tsx
@@ -97,7 +97,7 @@ const KnowledgeSourceDetail: FC<KnowledgeSourceDetailProps> = ({
             ),
         {
             revalidateOnFocus: false,
-            refreshInterval: blockPollingFiles ? undefined : 1000,
+            refreshInterval: blockPollingFiles ? undefined : 5000,
         }
     );
 
@@ -156,7 +156,7 @@ const KnowledgeSourceDetail: FC<KnowledgeSourceDetailProps> = ({
         if (knowledgeSource.state === KnowledgeSourceStatus.Synced) {
             getFiles.mutate();
         }
-    }, [knowledgeSource, getFiles]);
+    }, [knowledgeSource]);
 
     const onSourceUpdate = async (syncSchedule: string) => {
         const updatedSource = await KnowledgeService.updateKnowledgeSource(
@@ -176,8 +176,9 @@ const KnowledgeSourceDetail: FC<KnowledgeSourceDetailProps> = ({
             file.id,
             approved
         );
-        getFiles.mutate((files) =>
-            files?.map((f) => (f.id === file.id ? updatedFile : f))
+        getFiles.mutate(
+            (files) => files?.map((f) => (f.id === file.id ? updatedFile : f)),
+            false
         );
     };
 
@@ -203,8 +204,9 @@ const KnowledgeSourceDetail: FC<KnowledgeSourceDetailProps> = ({
             file.id,
             knowledgeSource.id
         );
-        getFiles.mutate((files) =>
-            files?.map((f) => (f.id === file.id ? updatedFile : f))
+        getFiles.mutate(
+            (files) => files?.map((f) => (f.id === file.id ? updatedFile : f)),
+            false
         );
     };
 


### PR DESCRIPTION
Don't make API requests when manually validating cache data. This is causing problem when ingesting large amount of files, as it is making too many requests in the server which cause server to load up. The knowledge files are stored in a same database withe `default` namespace so there is no index when retrieving them from database.

Also cut the interval from 1 second to 5 seconds to avoid putting too much load to server.

https://github.com/otto8-ai/otto8/issues/558