### PR TITLE
enhancement: Active selected link in sidebar state

### DIFF
--- a/ui/admin/app/components/sidebar/Sidebar.tsx
+++ b/ui/admin/app/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@remix-run/react";
+import { Link, useLocation } from "@remix-run/react";
 import {
     BotIcon,
     BrainIcon,
@@ -81,6 +81,7 @@ const items = [
 
 export function AppSidebar() {
     const { state } = useSidebar();
+    const location = useLocation();
     return (
         <Sidebar collapsible="icon">
             <SidebarRail />
@@ -108,12 +109,25 @@ export function AppSidebar() {
                                     <SidebarMenuButton
                                         asChild
                                         className="w-full"
+                                        isActive={location.pathname.startsWith(
+                                            item.url
+                                        )}
+                                        variant="spill"
                                     >
                                         <Link
                                             to={item.url}
                                             className="w-full flex items-center"
                                         >
-                                            <item.icon className="mr-2" />
+                                            <item.icon
+                                                className={cn(
+                                                    "mr-2",
+                                                    location.pathname.startsWith(
+                                                        item.url
+                                                    )
+                                                        ? "text-primary"
+                                                        : ""
+                                                )}
+                                            />
                                             <span>{item.title}</span>
                                         </Link>
                                     </SidebarMenuButton>

--- a/ui/admin/app/components/ui/sidebar.tsx
+++ b/ui/admin/app/components/ui/sidebar.tsx
@@ -415,7 +415,7 @@ const SidebarContent = React.forwardRef<
             ref={ref}
             data-sidebar="content"
             className={cn(
-                "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+                "flex min-h-0 flex-1 flex-col gap-2 overflow-hidden group-data-[collapsible=icon]:overflow-hidden",
                 className
             )}
             {...props}
@@ -534,6 +534,7 @@ const sidebarMenuButtonVariants = cva(
                     "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
                 outline:
                     "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+                spill: "w-full group-data-[collapsible=icon]:data-[active=true]:!bg-background group-data-[collapsible=icon]:data-[active=true]:!w-[calc(100%+20px)] hover:bg-background hover:w-[calc(100%+20px)] data-[active=true]:bg-background data-[active=true]:w-[calc(100%+20px)] pr-[10px]",
             },
             size: {
                 default: "h-8 text-sm",


### PR DESCRIPTION

<img width="317" alt="Screenshot 2024-12-02 at 9 42 49 AM" src="https://github.com/user-attachments/assets/1627dadb-48d3-4abe-ad9d-cf00f80d071c">
<img width="174" alt="Screenshot 2024-12-02 at 9 39 27 AM" src="https://github.com/user-attachments/assets/3d742f55-14f0-4d6b-81fc-4a06f807612b">


<img width="285" alt="Screenshot 2024-12-02 at 9 42 44 AM" src="https://github.com/user-attachments/assets/3f4af54c-f8b1-4250-8b3c-ba7507855399">
<img width="176" alt="Screenshot 2024-12-02 at 9 39 20 AM" src="https://github.com/user-attachments/assets/74928849-9a1d-4cb3-b3ef-f2e660fa29dd">


Random suggestion / thought! Noticed there wasn't an active state when clicking the links in the sidebar so throwing this one out there! 