### PR TITLE
fix: prevent event source from reconnecting after SSE close event

### DIFF
--- a/ui/admin/app/components/chat/ChatContext.tsx
+++ b/ui/admin/app/components/chat/ChatContext.tsx
@@ -181,10 +181,11 @@ function useMessageSource(threadId?: Nullish<string>) {
 
         if (!threadId) return;
 
-        const source = ThreadsService.getThreadEventSource(threadId);
-
         let replayComplete = false;
         let replayMessages: ChatEvent[] = [];
+
+        const source = ThreadsService.getThreadEventSource(threadId);
+        source.addEventListener("close", source.close);
 
         source.onmessage = (chunk) => {
             const event = JSON.parse(chunk.data) as ChatEvent;


### PR DESCRIPTION
After a workflow (or workflow authentication) was completed, the Server would close it's connection to the SSE, but the UI never closed the EventSource and would repeatedly attempt to reconnect causing a new api request every few seconds. This fix alleviates this by closing the connection in the UI whenever the server sends a `close` event