### PR TITLE
chore: update publish with aliasAssigned api change

### DIFF
--- a/ui/admin/app/components/agent/Agent.tsx
+++ b/ui/admin/app/components/agent/Agent.tsx
@@ -31,7 +31,7 @@ export function Agent({ className, onRefresh }: AgentProps) {
             if (agent.id === prev.id) {
                 return {
                     ...prev,
-                    aliasAssigned: agent.aliasAssigned ?? false,
+                    aliasAssigned: agent.aliasAssigned,
                 };
             }
 
@@ -64,7 +64,6 @@ export function Agent({ className, onRefresh }: AgentProps) {
             <ScrollArea className={cn("h-full", className)}>
                 <AgentPublishStatus
                     agent={agentUpdates}
-                    isUpdating={isUpdating}
                     onChange={partialSetAgent}
                 />
 

--- a/ui/admin/app/components/agent/AgentPublishStatus.tsx
+++ b/ui/admin/app/components/agent/AgentPublishStatus.tsx
@@ -15,13 +15,11 @@ import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
 
 type AgentPublishStatusProps = {
     agent: Agent;
-    isUpdating: boolean;
     onChange: (agent: Partial<Agent>) => void;
 };
 
 export function AgentPublishStatus({
     agent,
-    isUpdating,
     onChange,
 }: AgentPublishStatusProps) {
     const getAssistants = useSWR(
@@ -88,7 +86,8 @@ export function AgentPublishStatus({
             );
         }
 
-        if (isUpdating)
+        // if aliasAssigned is undefined, it is still resolving
+        if (agent.aliasAssigned === undefined)
             return <LoadingSpinner className="m-l-2 text-muted-foreground" />;
 
         if (!agent.aliasAssigned) return <div />;


### PR DESCRIPTION
Synced with Donnie and the changes made to the api for aliasAssigned were made:

* `undefined` means the alias is still resolving
*  `true` is alias has been assigned
* `false` is alias has not been assigned (whether published or not)

It looks like `aliasAssigned` is properly updated on the revalidation call so doesn't look like polling is needed currently.