### PR TITLE
fix: display error if tool creation failed

### DIFF
--- a/ui/admin/app/components/composed/ErrorDialog.tsx
+++ b/ui/admin/app/components/composed/ErrorDialog.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Button } from "~/components/ui/button";
 import {
     Dialog,
@@ -16,11 +14,7 @@ type ErrorDialogProps = {
     onClose: () => void;
 };
 
-const ErrorDialog: React.FC<ErrorDialogProps> = ({
-    error,
-    isOpen,
-    onClose,
-}) => {
+export function ErrorDialog({ error, isOpen, onClose }: ErrorDialogProps) {
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
             <DialogContent className="max-w-[850px]">
@@ -36,6 +30,4 @@ const ErrorDialog: React.FC<ErrorDialogProps> = ({
             </DialogContent>
         </Dialog>
     );
-};
-
-export default ErrorDialog;
+}

--- a/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
+++ b/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
@@ -26,8 +26,8 @@ import {
 import { KnowledgeService } from "~/lib/service/api/knowledgeService";
 import { assetUrl } from "~/lib/utils";
 
+import { ErrorDialog } from "~/components/composed/ErrorDialog";
 import AddSourceModal from "~/components/knowledge/AddSourceModal";
-import ErrorDialog from "~/components/knowledge/ErrorDialog";
 import FileStatusIcon from "~/components/knowledge/FileStatusIcon";
 import RemoteFileAvatar from "~/components/knowledge/KnowledgeSourceAvatar";
 import KnowledgeSourceDetail from "~/components/knowledge/KnowledgeSourceDetail";

--- a/ui/admin/app/components/knowledge/KnowledgeSourceDetail.tsx
+++ b/ui/admin/app/components/knowledge/KnowledgeSourceDetail.tsx
@@ -15,8 +15,8 @@ import {
 } from "~/lib/model/knowledge";
 import { KnowledgeService } from "~/lib/service/api/knowledgeService";
 
+import { ErrorDialog } from "~/components/composed/ErrorDialog";
 import CronDialog from "~/components/knowledge/CronDialog";
-import ErrorDialog from "~/components/knowledge/ErrorDialog";
 import FileTreeNode, { FileNode } from "~/components/knowledge/FileTree";
 import KnowledgeSourceAvatar from "~/components/knowledge/KnowledgeSourceAvatar";
 import OauthSignDialog from "~/components/knowledge/OAuthSignDialog";

--- a/ui/admin/app/components/tools/CreateTool.tsx
+++ b/ui/admin/app/components/tools/CreateTool.tsx
@@ -1,7 +1,9 @@
 import { PlusCircle } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
+import useSWR, { SWRResponse } from "swr";
 
-import { CreateToolReference } from "~/lib/model/toolReferences";
+import { CreateToolReference, ToolReference } from "~/lib/model/toolReferences";
 import { ToolReferenceService } from "~/lib/service/api/toolreferenceService";
 
 import { Button } from "~/components/ui/button";
@@ -9,22 +11,61 @@ import { Input } from "~/components/ui/input";
 import { useAsync } from "~/hooks/useAsync";
 
 interface CreateToolProps {
+    onError: (error: string) => void;
     onSuccess: () => void;
 }
 
-export function CreateTool({ onSuccess }: CreateToolProps) {
+export function CreateTool({ onError, onSuccess }: CreateToolProps) {
     const { register, handleSubmit, reset } = useForm<CreateToolReference>();
 
-    const { execute: onSubmit, isLoading } = useAsync(
-        async (data: CreateToolReference) => {
-            await ToolReferenceService.createToolReference({
-                toolReference: { ...data, toolType: "tool" },
-            });
-            reset();
-            onSuccess();
+    const [loadingToolId, setLoadingToolId] = useState("");
+    const getLoadingTool: SWRResponse<ToolReference, Error> = useSWR(
+        loadingToolId
+            ? ToolReferenceService.getToolReferenceById.key(loadingToolId)
+            : null,
+        ({ toolReferenceId }) =>
+            ToolReferenceService.getToolReferenceById(toolReferenceId),
+        {
+            revalidateOnFocus: false,
+            refreshInterval: 2000,
         }
     );
 
+    const handleCreatedTool = useCallback(
+        (loadedTool: ToolReference) => {
+            setLoadingToolId("");
+            reset();
+            if (loadedTool.error) {
+                onError(loadedTool.error);
+            } else {
+                onSuccess();
+            }
+        },
+        [onError, reset, onSuccess]
+    );
+
+    useEffect(() => {
+        if (!loadingToolId) return;
+
+        const { isLoading, data } = getLoadingTool;
+        if (isLoading) return;
+
+        if (data?.resolved) {
+            handleCreatedTool(data);
+        }
+    }, [getLoadingTool, handleCreatedTool, loadingToolId]);
+
+    const { execute: onSubmit, isLoading } = useAsync(
+        async (data: CreateToolReference) => {
+            const response = await ToolReferenceService.createToolReference({
+                toolReference: { ...data, toolType: "tool" },
+            });
+
+            setLoadingToolId(response.id);
+        }
+    );
+
+    const pending = isLoading || !!loadingToolId;
     return (
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
             <div>
@@ -37,9 +78,9 @@ export function CreateTool({ onSuccess }: CreateToolProps) {
                 />
             </div>
             <div className="flex justify-end">
-                <Button type="submit" disabled={isLoading}>
+                <Button type="submit" disabled={pending}>
                     <PlusCircle className="w-4 h-4 mr-2" />
-                    {isLoading ? "Creating..." : "Register Tool"}
+                    {pending ? "Creating..." : "Register Tool"}
                 </Button>
             </div>
         </form>

--- a/ui/admin/app/components/tools/CreateTool.tsx
+++ b/ui/admin/app/components/tools/CreateTool.tsx
@@ -1,7 +1,7 @@
 import { PlusCircle } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import useSWR, { SWRResponse } from "swr";
+import useSWR from "swr";
 
 import { CreateToolReference, ToolReference } from "~/lib/model/toolReferences";
 import { ToolReferenceService } from "~/lib/service/api/toolreferenceService";
@@ -19,7 +19,7 @@ export function CreateTool({ onError, onSuccess }: CreateToolProps) {
     const { register, handleSubmit, reset } = useForm<CreateToolReference>();
 
     const [loadingToolId, setLoadingToolId] = useState("");
-    const getLoadingTool: SWRResponse<ToolReference, Error> = useSWR(
+    const getLoadingTool = useSWR(
         loadingToolId
             ? ToolReferenceService.getToolReferenceById.key(loadingToolId)
             : null,
@@ -78,9 +78,13 @@ export function CreateTool({ onError, onSuccess }: CreateToolProps) {
                 />
             </div>
             <div className="flex justify-end">
-                <Button type="submit" disabled={pending}>
-                    <PlusCircle className="w-4 h-4 mr-2" />
-                    {pending ? "Creating..." : "Register Tool"}
+                <Button
+                    type="submit"
+                    disabled={pending}
+                    loading={pending}
+                    startContent={<PlusCircle />}
+                >
+                    Register Tool
                 </Button>
             </div>
         </form>

--- a/ui/admin/app/lib/model/toolReferences.ts
+++ b/ui/admin/app/lib/model/toolReferences.ts
@@ -5,6 +5,7 @@ export type ToolReferenceBase = {
     name: string;
     toolType: ToolReferenceType;
     reference: string;
+    resolved?: boolean;
     metadata?: Record<string, string>;
 };
 

--- a/ui/admin/app/routes/_auth.tools._index.tsx
+++ b/ui/admin/app/routes/_auth.tools._index.tsx
@@ -5,6 +5,7 @@ import useSWR, { preload } from "swr";
 import { ToolReferenceService } from "~/lib/service/api/toolreferenceService";
 
 import { TypographyH2 } from "~/components/Typography";
+import ErrorDialog from "~/components/knowledge/ErrorDialog";
 import { CreateTool } from "~/components/tools/CreateTool";
 import { ToolGrid } from "~/components/tools/toolGrid";
 import { Button } from "~/components/ui/button";
@@ -38,6 +39,7 @@ export default function Tools() {
 
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState("");
+    const [errorDialogError, setErrorDialogError] = useState("");
 
     const handleCreateSuccess = () => {
         mutate();
@@ -47,6 +49,12 @@ export default function Tools() {
     const handleDelete = async (id: string) => {
         await ToolReferenceService.deleteToolReference(id);
         mutate();
+    };
+
+    const handleErrorDialogError = (error: string) => {
+        mutate();
+        setErrorDialogError(error);
+        setIsDialogOpen(false);
     };
 
     return (
@@ -81,9 +89,17 @@ export default function Tools() {
                                     agents.
                                 </DialogDescription>
                             </DialogHeader>
-                            <CreateTool onSuccess={handleCreateSuccess} />
+                            <CreateTool
+                                onError={handleErrorDialogError}
+                                onSuccess={handleCreateSuccess}
+                            />
                         </DialogContent>
                     </Dialog>
+                    <ErrorDialog
+                        error={errorDialogError}
+                        isOpen={errorDialogError !== ""}
+                        onClose={() => setErrorDialogError("")}
+                    />
                 </div>
             </div>
 

--- a/ui/admin/app/routes/_auth.tools._index.tsx
+++ b/ui/admin/app/routes/_auth.tools._index.tsx
@@ -5,7 +5,7 @@ import useSWR, { preload } from "swr";
 import { ToolReferenceService } from "~/lib/service/api/toolreferenceService";
 
 import { TypographyH2 } from "~/components/Typography";
-import ErrorDialog from "~/components/knowledge/ErrorDialog";
+import { ErrorDialog } from "~/components/composed/ErrorDialog";
 import { CreateTool } from "~/components/tools/CreateTool";
 import { ToolGrid } from "~/components/tools/toolGrid";
 import { Button } from "~/components/ui/button";


### PR DESCRIPTION
Addresses #502 

After syncing with Donnie, `resolved` field was added to the ToolReference. Similarly to `aliasAssigned`:
* `undefined`, the creation of tool is still resolving
*  `true/false`, tool has or has not been resolved

Once resolved, `error` should be supplied.

Needed to implement polling to fetch the ToolReference until it is resolved. 

Once resolved, error is shown in ErrorDialog, but lemme know if there is a different preferred error handling!

https://github.com/user-attachments/assets/2601e797-568e-45bc-9e8e-1737263000b9


(Tempted to see if I can make it scroll to the created tool once it's completed so user immediately sees their uploaded tool or maybe sort by recently created so it immediately shows at the top?)