### PR TITLE
Fix: run pnpm build in package script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ ui: ui-admin ui-user
 
 ui-admin:
 	cd ui/admin && \
-	pnpm install
+	pnpm install && \
+	pnpm run build
 
 ui-user:
 	cd ui/user && \


### PR DESCRIPTION
We are missing the build step in packaging script that are used to build docker images