### PR TITLE
Feat/admin/model-create-and-edit-dropdown

### DIFF
--- a/ui/admin/app/components/model/AddModel.tsx
+++ b/ui/admin/app/components/model/AddModel.tsx
@@ -24,6 +24,7 @@ export function AddModel() {
 
             <DialogContent>
                 <DialogTitle>Create Model</DialogTitle>
+
                 <DialogDescription hidden>Create Model</DialogDescription>
 
                 <ModelForm onSubmit={() => setOpen(false)} />

--- a/ui/admin/app/components/model/ModelForm.tsx
+++ b/ui/admin/app/components/model/ModelForm.tsx
@@ -14,6 +14,7 @@ import {
     getModelUsageLabel,
 } from "~/lib/model/models";
 import { ModelApiService } from "~/lib/service/api/modelApiService";
+import { ModelProviderApiService } from "~/lib/service/api/modelProviderApiService";
 
 import { ControlledCustomInput } from "~/components/form/controlledInputs";
 import { Button } from "~/components/ui/button";
@@ -38,8 +39,8 @@ export function ModelForm(props: ModelFormProps) {
     const { model, onSubmit } = props;
 
     const { data: modelProviders } = useSWR(
-        ModelApiService.getModelProviders.key(),
-        ModelApiService.getModelProviders
+        ModelProviderApiService.getModelProviders.key(),
+        () => ModelProviderApiService.getModelProviders()
     );
 
     const updateModel = useAsync(ModelApiService.updateModel, {
@@ -93,8 +94,7 @@ export function ModelForm(props: ModelFormProps) {
     const providerName = (provider: ModelProvider) => {
         let text = provider.name || provider.id;
 
-        if (!provider.modelProviderStatus.configured)
-            text += " (not configured)";
+        if (!provider.configured) text += " (not configured)";
 
         return text;
     };
@@ -118,10 +118,7 @@ export function ModelForm(props: ModelFormProps) {
                                     <SelectItem
                                         key={provider.id}
                                         value={provider.id}
-                                        disabled={
-                                            !provider.modelProviderStatus
-                                                .configured
-                                        }
+                                        disabled={!provider.configured}
                                     >
                                         {providerName(provider)}
                                     </SelectItem>

--- a/ui/admin/app/components/model/ModelForm.tsx
+++ b/ui/admin/app/components/model/ModelForm.tsx
@@ -79,7 +79,9 @@ export function ModelForm(props: ModelFormProps) {
         ModelApiService.getAvailableModelsByProvider.key(
             form.watch("modelProvider")
         ),
-        ({ provider }) => ModelApiService.getAvailableModelsByProvider(provider)
+        ({ provider }) =>
+            ModelApiService.getAvailableModelsByProvider(provider),
+        { revalidateIfStale: false }
     );
 
     const { loading, submit } = getSubmitInfo();

--- a/ui/admin/app/lib/model/availableModels.ts
+++ b/ui/admin/app/lib/model/availableModels.ts
@@ -1,0 +1,10 @@
+import { ModelUsage } from "~/lib/model/models";
+import { EntityMeta } from "~/lib/model/primitives";
+
+export type AvailableModel = EntityMeta<{ usage?: ModelUsage }> & {
+    object: string;
+    owned_by: string;
+    permission: string[];
+    root: string;
+    parent: string;
+};

--- a/ui/admin/app/lib/model/models.ts
+++ b/ui/admin/app/lib/model/models.ts
@@ -57,41 +57,6 @@ export type ModelProvider = EntityMeta & {
     toolType: "modelProvider";
 };
 
-// note(ryanhopperlowe): these values are hardcoded for now
-// ideally they should come from the backend
-const ModelToProviderMap = {
-    "openai-model-provider": [
-        "text-embedding-3-small",
-        "dall-e-3",
-        "gpt-4o-mini",
-        "gpt-3.5-turbo",
-        "text-embedding-ada-002",
-        "gpt-4o",
-    ],
-    "azure-openai-model-provider": [
-        "text-embedding-3-small",
-        "dall-e-3",
-        "gpt-4o-mini",
-        "gpt-3.5-turbo",
-        "text-embedding-ada-002",
-        "gpt-4o",
-    ],
-    "anthropic-model-provider": [
-        "claude-3-opus-latest",
-        "claude-3-5-sonnet-latest",
-        "claude-3-5-haiku-latest",
-    ],
-    "ollama-model-provider": ["llama3.2"],
-    "voyage-model-provider": [
-        "voyage-3",
-        "voyage-3-lite",
-        "voyage-finance-2",
-        "voyage-multilingual-2",
-        "voyage-law-2",
-        "voyage-code-2",
-    ],
-};
-
 export const ModelAliasToUsageMap = {
     llm: ModelUsage.LLM,
     "llm-mini": ModelUsage.LLM,
@@ -103,9 +68,4 @@ export function getModelUsageFromAlias(alias: string) {
     if (!(alias in ModelAliasToUsageMap)) return null;
 
     return ModelAliasToUsageMap[alias as keyof typeof ModelAliasToUsageMap];
-}
-
-export function getModelsForProvider(providerId: string) {
-    if (!providerId || !(providerId in ModelToProviderMap)) return [];
-    return ModelToProviderMap[providerId as keyof typeof ModelToProviderMap];
 }

--- a/ui/admin/app/lib/model/models.ts
+++ b/ui/admin/app/lib/model/models.ts
@@ -47,15 +47,14 @@ export const ModelManifestSchema = z.object({
     usage: z.nativeEnum(ModelUsage),
 });
 
-export type ModelProvider = EntityMeta & {
-    description?: string;
-    builtin: boolean;
-    active: boolean;
-    modelProviderStatus: ModelProviderStatus;
+type ModelProviderManifest = {
     name: string;
-    reference: string;
-    toolType: "modelProvider";
+    toolReference: string;
 };
+
+export type ModelProvider = EntityMeta &
+    ModelProviderManifest &
+    ModelProviderStatus;
 
 export const ModelAliasToUsageMap = {
     llm: ModelUsage.LLM,

--- a/ui/admin/app/lib/routers/apiRoutes.ts
+++ b/ui/admin/app/lib/routers/apiRoutes.ts
@@ -176,6 +176,9 @@ export const ApiRoutes = {
         getAvailableModelsByProvider: (provider: string) =>
             buildUrl(`/available-models/${provider}`),
     },
+    modelProviders: {
+        getModelProviders: () => buildUrl("/model-providers"),
+    },
     defaultModelAliases: {
         base: () => buildUrl("/default-model-aliases"),
         getAliases: () => buildUrl("/default-model-aliases"),

--- a/ui/admin/app/lib/routers/apiRoutes.ts
+++ b/ui/admin/app/lib/routers/apiRoutes.ts
@@ -172,6 +172,9 @@ export const ApiRoutes = {
         createModel: () => buildUrl(`/models`),
         updateModel: (modelId: string) => buildUrl(`/models/${modelId}`),
         deleteModel: (modelId: string) => buildUrl(`/models/${modelId}`),
+        getAvailableModels: () => buildUrl("/available-models"),
+        getAvailableModelsByProvider: (provider: string) =>
+            buildUrl(`/available-models/${provider}`),
     },
     defaultModelAliases: {
         base: () => buildUrl("/default-model-aliases"),

--- a/ui/admin/app/lib/service/api/modelApiService.ts
+++ b/ui/admin/app/lib/service/api/modelApiService.ts
@@ -40,7 +40,6 @@ getModelProviders.key = () => ({
 });
 
 async function getAvailableModelsByProvider(provider: string) {
-    await new Promise((resolve) => setTimeout(resolve, 3000));
     const { data } = await request<{ data?: AvailableModel[] }>({
         url: ApiRoutes.models.getAvailableModelsByProvider(provider).url,
     });
@@ -57,7 +56,6 @@ getAvailableModelsByProvider.key = (provider?: Nullish<string>) => {
 };
 
 async function createModel(manifest: ModelManifest) {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     const { data } = await request<Model>({
         url: ApiRoutes.models.createModel().url,
         method: "POST",
@@ -68,8 +66,6 @@ async function createModel(manifest: ModelManifest) {
 }
 
 async function updateModel(modelId: string, manifest: ModelManifest) {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
     const { data } = await request<Model>({
         url: ApiRoutes.models.updateModel(modelId).url,
         method: "PUT",

--- a/ui/admin/app/lib/service/api/modelApiService.ts
+++ b/ui/admin/app/lib/service/api/modelApiService.ts
@@ -1,3 +1,4 @@
+import { AvailableModel } from "~/lib/model/availableModels";
 import { Model, ModelManifest, ModelProvider } from "~/lib/model/models";
 import { ApiRoutes } from "~/lib/routers/apiRoutes";
 import { request } from "~/lib/service/api/primitives";
@@ -38,6 +39,23 @@ getModelProviders.key = () => ({
     url: ApiRoutes.toolReferences.base({ type: "modelProvider" }).path,
 });
 
+async function getAvailableModelsByProvider(provider: string) {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    const { data } = await request<{ data?: AvailableModel[] }>({
+        url: ApiRoutes.models.getAvailableModelsByProvider(provider).url,
+    });
+
+    return data.data ?? [];
+}
+getAvailableModelsByProvider.key = (provider?: Nullish<string>) => {
+    if (!provider) return null;
+
+    return {
+        url: ApiRoutes.models.getAvailableModelsByProvider(provider).path,
+        provider,
+    };
+};
+
 async function createModel(manifest: ModelManifest) {
     await new Promise((resolve) => setTimeout(resolve, 1000));
     const { data } = await request<Model>({
@@ -72,6 +90,7 @@ export const ModelApiService = {
     getModels,
     getModelById,
     getModelProviders,
+    getAvailableModelsByProvider,
     createModel,
     updateModel,
     deleteModel,

--- a/ui/admin/app/lib/service/api/modelApiService.ts
+++ b/ui/admin/app/lib/service/api/modelApiService.ts
@@ -1,5 +1,5 @@
 import { AvailableModel } from "~/lib/model/availableModels";
-import { Model, ModelManifest, ModelProvider } from "~/lib/model/models";
+import { Model, ModelManifest } from "~/lib/model/models";
 import { ApiRoutes } from "~/lib/routers/apiRoutes";
 import { request } from "~/lib/service/api/primitives";
 
@@ -27,17 +27,6 @@ getModelById.key = (modelId?: string) => {
         modelId,
     };
 };
-
-async function getModelProviders() {
-    const { data } = await request<{ items?: ModelProvider[] }>({
-        url: ApiRoutes.toolReferences.base({ type: "modelProvider" }).url,
-    });
-
-    return data.items ?? [];
-}
-getModelProviders.key = () => ({
-    url: ApiRoutes.toolReferences.base({ type: "modelProvider" }).path,
-});
 
 async function getAvailableModelsByProvider(provider: string) {
     const { data } = await request<{ data?: AvailableModel[] }>({
@@ -85,7 +74,6 @@ async function deleteModel(modelId: string) {
 export const ModelApiService = {
     getModels,
     getModelById,
-    getModelProviders,
     getAvailableModelsByProvider,
     createModel,
     updateModel,

--- a/ui/admin/app/lib/service/api/modelProviderApiService.ts
+++ b/ui/admin/app/lib/service/api/modelProviderApiService.ts
@@ -1,0 +1,16 @@
+import { ModelProvider } from "~/lib/model/models";
+import { ApiRoutes } from "~/lib/routers/apiRoutes";
+import { request } from "~/lib/service/api/primitives";
+
+async function getModelProviders() {
+    const { data } = await request<{ items?: ModelProvider[] }>({
+        url: ApiRoutes.modelProviders.getModelProviders().url,
+    });
+
+    return data.items ?? [];
+}
+getModelProviders.key = () => ({
+    url: ApiRoutes.modelProviders.getModelProviders().path,
+});
+
+export const ModelProviderApiService = { getModelProviders };

--- a/ui/admin/app/routes/_auth.models.tsx
+++ b/ui/admin/app/routes/_auth.models.tsx
@@ -6,6 +6,7 @@ import useSWR, { preload } from "swr";
 import { Model } from "~/lib/model/models";
 import { DefaultModelAliasApiService } from "~/lib/service/api/defaultModelAliasApiService";
 import { ModelApiService } from "~/lib/service/api/modelApiService";
+import { ModelProviderApiService } from "~/lib/service/api/modelProviderApiService";
 
 import { TypographyH2 } from "~/components/Typography";
 import { DataTable } from "~/components/composed/DataTable";
@@ -24,8 +25,8 @@ export async function clientLoader() {
     await Promise.all([
         preload(ModelApiService.getModels.key(), ModelApiService.getModels),
         preload(
-            ModelApiService.getModelProviders.key(),
-            ModelApiService.getModelProviders
+            ModelProviderApiService.getModelProviders.key(),
+            ModelProviderApiService.getModelProviders
         ),
         preload(
             DefaultModelAliasApiService.getAliases.key(),
@@ -44,8 +45,8 @@ export default function Models() {
     );
 
     const { data: providers } = useSWR(
-        ModelApiService.getModelProviders.key(),
-        ModelApiService.getModelProviders
+        ModelProviderApiService.getModelProviders.key(),
+        ModelProviderApiService.getModelProviders
     );
 
     const providerMap = useMemo(() => {


### PR DESCRIPTION
This PR improves how we populate the `Target Model` dropdown in the create/edit model form.

- Options are fetched from an api that filters by model provider
- upon selecting a model, the `usage` field will be prepopulated according to the available model's metadata