### PR TITLE
feat: RunSpec.Timeout to override default 10m run timeout

### DIFF
--- a/pkg/controller/handlers/knowledgesource/knowledgesource.go
+++ b/pkg/controller/handlers/knowledgesource/knowledgesource.go
@@ -199,7 +199,7 @@ func (k *Handler) Sync(req router.Request, _ router.Response) error {
 
 	invokeOpts := invoke.SystemTaskOptions{
 		CredentialContextIDs: []string{credentialContextID},
-		Timeout:              30 * time.Minute,
+		Timeout:              1 * time.Hour,
 	}
 
 	thread, err := getThread(req.Ctx, req.Client, source)

--- a/pkg/controller/handlers/knowledgesource/knowledgesource.go
+++ b/pkg/controller/handlers/knowledgesource/knowledgesource.go
@@ -199,6 +199,7 @@ func (k *Handler) Sync(req router.Request, _ router.Response) error {
 
 	invokeOpts := invoke.SystemTaskOptions{
 		CredentialContextIDs: []string{credentialContextID},
+		Timeout:              30 * time.Minute,
 	}
 
 	thread, err := getThread(req.Ctx, req.Client, source)

--- a/pkg/invoke/system.go
+++ b/pkg/invoke/system.go
@@ -3,6 +3,7 @@ package invoke
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	v1 "github.com/otto8-ai/otto8/pkg/storage/apis/otto.otto8.ai/v1"
 )
@@ -10,12 +11,16 @@ import (
 type SystemTaskOptions struct {
 	CredentialContextIDs []string
 	Env                  []string
+	Timeout              time.Duration
 }
 
 func complete(opts []SystemTaskOptions) (result SystemTaskOptions) {
 	for _, opt := range opts {
 		result.CredentialContextIDs = append(result.CredentialContextIDs, opt.CredentialContextIDs...)
 		result.Env = append(result.Env, opt.Env...)
+		if opt.Timeout > result.Timeout {
+			result.Timeout = opt.Timeout // highest timeout wins
+		}
 	}
 	return
 }
@@ -51,5 +56,6 @@ func (i *Invoker) SystemTask(ctx context.Context, thread *v1.Thread, tool, input
 		Env:                  opt.Env,
 		CredentialContextIDs: opt.CredentialContextIDs,
 		Synchronous:          true,
+		Timeout:              opt.Timeout,
 	})
 }

--- a/pkg/storage/apis/otto.otto8.ai/v1/run.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/run.go
@@ -74,6 +74,7 @@ type RunSpec struct {
 	ToolReferenceType     types.ToolReferenceType `json:"toolReferenceType,omitempty"`
 	CredentialContextIDs  []string                `json:"credentialContextIDs,omitempty"`
 	DefaultModel          string                  `json:"defaultModel,omitempty"`
+	Timeout               metav1.Duration         `json:"timeout,omitempty"`
 }
 
 func (in *Run) DeleteRefs() []Ref {


### PR DESCRIPTION
... also set default knowledge data-source sync timeout to ~30m~ 1h, as it can easily happen that website-scraping exceeds 10 minutes.

Ref https://github.com/otto8-ai/otto8/issues/743