### PR TITLE
feat: set default aliases if configuring OpenAI with env var

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -37,7 +37,7 @@ func (c *Controller) PostStart(ctx context.Context) error {
 		return fmt.Errorf("failed to apply data: %w", err)
 	}
 	go c.toolRefHandler.PollRegistry(ctx, c.services.Router.Backend())
-	return c.toolRefHandler.EnsureOpenAIEnvCredential(ctx, c.services.Router.Backend())
+	return c.toolRefHandler.EnsureOpenAIEnvCredentialAndDefaults(ctx, c.services.Router.Backend())
 }
 
 func (c *Controller) Start(ctx context.Context) error {


### PR DESCRIPTION
When the user configures the OpenAI model provider with an environment variable, this change will ensure that the models are populated as expected and that the default model aliases are set to reasonable defaults. If the default model aliases are already set, then this change will not touch them.