### PR TITLE
feat: view models for a model provider & configure helper text for inputs

### DIFF
--- a/ui/admin/app/components/model-providers/ModelProviderForm.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderForm.tsx
@@ -14,12 +14,20 @@ import {
     ParamFormValues,
 } from "~/components/composed/NameDescriptionForm";
 import { ControlledInput } from "~/components/form/controlledInputs";
-import { ModelProviderConfigurationLinks } from "~/components/model-providers/constants";
+import {
+    ModelProviderConfigurationLinks,
+    ModelProviderRequiredTooltips,
+} from "~/components/model-providers/constants";
 import { Button } from "~/components/ui/button";
 import { Form } from "~/components/ui/form";
 import { Link } from "~/components/ui/link";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Separator } from "~/components/ui/separator";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "~/components/ui/tooltip";
 import { useAsync } from "~/hooks/useAsync";
 
 const formSchema = z.object({
@@ -59,7 +67,8 @@ const translateUserFriendlyLabel = (label: string) => {
         }, label)
         .toLowerCase()
         .replace(/_/g, " ")
-        .replace(/\b\w/g, (char: string) => char.toUpperCase());
+        .replace(/\b\w/g, (char: string) => char.toUpperCase())
+        .trim();
 };
 
 const getInitialRequiredParams = (
@@ -171,15 +180,23 @@ export function ModelProviderForm({
                         >
                             {requiredConfigParamFields.fields.map(
                                 (field, i) => (
-                                    <ControlledInput
+                                    <div
                                         key={field.id}
-                                        label={field.label}
-                                        control={form.control}
-                                        name={`requiredConfigParams.${i}.value`}
-                                        classNames={{
-                                            wrapper: "flex-auto bg-background",
-                                        }}
-                                    />
+                                        className="flex gap-2 items-center justify-center"
+                                    >
+                                        <ControlledInput
+                                            key={field.id}
+                                            label={renderLabelWithTooltip(
+                                                field.label
+                                            )}
+                                            control={form.control}
+                                            name={`requiredConfigParams.${i}.value`}
+                                            classNames={{
+                                                wrapper:
+                                                    "flex-auto bg-background",
+                                            }}
+                                        />
+                                    </div>
                                 )
                             )}
                         </form>
@@ -189,26 +206,17 @@ export function ModelProviderForm({
                         <>
                             <Separator className="my-4" />
 
-                            <div className="flex items-center gap-2">
+                            <div className="flex items-center">
                                 <TypographyH4 className="font-semibold text-md">
                                     Custom Configuration (Optional)
                                 </TypographyH4>
                                 {ModelProviderConfigurationLinks[
                                     modelProvider.id
-                                ] ? (
-                                    <Link
-                                        as="button"
-                                        variant="ghost"
-                                        size="icon"
-                                        to={
-                                            ModelProviderConfigurationLinks[
-                                                modelProvider.id
-                                            ]
-                                        }
-                                    >
-                                        <CircleHelpIcon className="text-muted-foreground" />
-                                    </Link>
-                                ) : null}
+                                ]
+                                    ? renderCustomConfigTooltip(
+                                          modelProvider.id
+                                      )
+                                    : null}
                             </div>
                             <NameDescriptionForm
                                 defaultValues={form.watch(
@@ -238,4 +246,55 @@ export function ModelProviderForm({
             </div>
         </div>
     );
+
+    function renderCustomConfigTooltip(modelProviderId: string) {
+        const link = ModelProviderConfigurationLinks[modelProviderId];
+        return (
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Link to={link} size="icon" variant="ghost" as="button">
+                        <CircleHelpIcon className="text-muted-foreground" />
+                    </Link>
+                </TooltipTrigger>
+
+                <TooltipContent
+                    side="right"
+                    className="bg-secondary text-foreground max-w-80"
+                >
+                    This model provider supports additional environment variable
+                    configurations. Click to learn more.
+                </TooltipContent>
+            </Tooltip>
+        );
+    }
+
+    function renderLabelWithTooltip(label: string) {
+        const tooltip =
+            ModelProviderRequiredTooltips[modelProvider.id]?.[label];
+        return (
+            <div className="flex items-center">
+                {label}
+                {tooltip && (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                size="icon"
+                                variant="ghost"
+                                onClick={(e) => e.preventDefault()}
+                            >
+                                <CircleHelpIcon className="text-muted-foreground" />
+                            </Button>
+                        </TooltipTrigger>
+
+                        <TooltipContent
+                            side="right"
+                            className="bg-secondary text-foreground max-w-80"
+                        >
+                            {tooltip}
+                        </TooltipContent>
+                    </Tooltip>
+                )}
+            </div>
+        );
+    }
 }

--- a/ui/admin/app/components/model-providers/ModelProviderLists.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderLists.tsx
@@ -5,9 +5,10 @@ import { ModelProvider } from "~/lib/model/modelProviders";
 
 import { ModelProviderConfigure } from "~/components/model-providers/ModelProviderConfigure";
 import { ModelProviderIcon } from "~/components/model-providers/ModelProviderIcon";
+import { ModelProvidersModels } from "~/components/model-providers/ModelProviderModels";
 import { ModelProviderLinks } from "~/components/model-providers/constants";
 import { Badge } from "~/components/ui/badge";
-import { Card, CardContent } from "~/components/ui/card";
+import { Card, CardContent, CardHeader } from "~/components/ui/card";
 
 export function ModelProviderList({
     modelProviders,
@@ -19,7 +20,16 @@ export function ModelProviderList({
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4">
                 {modelProviders.map((modelProvider) => (
                     <Card key={modelProvider.id}>
-                        <CardContent className="flex flex-col items-center gap-4 pt-6">
+                        <CardHeader className="pb-0 flex flex-row justify-end">
+                            {modelProvider.configured ? (
+                                <ModelProvidersModels
+                                    modelProvider={modelProvider}
+                                />
+                            ) : (
+                                <div className="w-9 h-9" />
+                            )}
+                        </CardHeader>
+                        <CardContent className="flex flex-col items-center gap-4">
                             <Link to={ModelProviderLinks[modelProvider.id]}>
                                 <ModelProviderIcon
                                     modelProvider={modelProvider}

--- a/ui/admin/app/components/model-providers/ModelProviderModels.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderModels.tsx
@@ -1,0 +1,110 @@
+import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { SettingsIcon } from "lucide-react";
+import useSWR from "swr";
+
+import { ModelProvider } from "~/lib/model/modelProviders";
+import { Model, getModelUsageLabel } from "~/lib/model/models";
+import { ModelApiService } from "~/lib/service/api/modelApiService";
+
+import { DataTable } from "~/components/composed/DataTable";
+import { ModelProviderIcon } from "~/components/model-providers/ModelProviderIcon";
+import { DeleteModel } from "~/components/model/DeleteModel";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "~/components/ui/dialog";
+import { ScrollArea } from "~/components/ui/scroll-area";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "~/components/ui/tooltip";
+
+type ModelsConfigureProps = {
+    modelProvider: ModelProvider;
+};
+
+const columnHelper = createColumnHelper<Model>();
+
+export function ModelProvidersModels({ modelProvider }: ModelsConfigureProps) {
+    const getModels = useSWR(
+        ModelApiService.getModels.key(),
+        ModelApiService.getModels
+    );
+
+    const models =
+        getModels.data?.filter(
+            (model) => model.modelProvider === modelProvider.id
+        ) ?? [];
+    return (
+        <Dialog>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <DialogTrigger asChild>
+                        <Button size="icon" variant="ghost">
+                            <SettingsIcon />
+                        </Button>
+                    </DialogTrigger>
+                </TooltipTrigger>
+                <TooltipContent>{modelProvider.name} Models</TooltipContent>
+            </Tooltip>
+
+            <DialogDescription hidden>
+                Configure & View Models of a Modal Provider.
+            </DialogDescription>
+
+            <DialogContent
+                className="p-0 gap-0"
+                classNames={{
+                    content: "max-w-4xl",
+                }}
+            >
+                <DialogHeader className="space-y-0 border-b-secondary border-b">
+                    <DialogTitle className="flex items-center gap-2 px-6 py-4">
+                        <ModelProviderIcon modelProvider={modelProvider} />{" "}
+                        {modelProvider.name} Models
+                    </DialogTitle>
+                </DialogHeader>
+                <ScrollArea className="h-[50vh]">
+                    <DataTable
+                        columns={getColumns()}
+                        data={models}
+                        sort={[{ id: "id", desc: true }]}
+                    />
+                </ScrollArea>
+            </DialogContent>
+        </Dialog>
+    );
+
+    function getColumns(): ColumnDef<Model, string>[] {
+        return [
+            columnHelper.accessor((model) => model.id, {
+                id: "id",
+                header: "Model",
+            }),
+            columnHelper.display({
+                id: "usage",
+                header: "Usage",
+                cell: ({ row }) => (
+                    <Badge variant="outline">
+                        {getModelUsageLabel(row.original.usage)}
+                    </Badge>
+                ),
+            }),
+            columnHelper.display({
+                id: "actions",
+                cell: ({ row }) => (
+                    <div className="flex justify-end">
+                        <DeleteModel id={row.original.id} />
+                    </div>
+                ),
+            }),
+        ];
+    }
+}

--- a/ui/admin/app/components/model-providers/constants.ts
+++ b/ui/admin/app/components/model-providers/constants.ts
@@ -19,3 +19,27 @@ export const ModelProviderConfigurationLinks = {
     [CommonModelProviderIds.AZURE_OPENAI]:
         "https://docs.otto8.ai/configuration/model-providers#azure-openai",
 };
+
+export const ModelProviderRequiredTooltips: {
+    [key: string]: {
+        [key: string]: string;
+    };
+} = {
+    [CommonModelProviderIds.OLLAMA]: {
+        Host: "IP Address for the ollama server (eg. 127.0.0.1:1234)",
+    },
+    [CommonModelProviderIds.AZURE_OPENAI]: {
+        Endpoint:
+            "Endpoint for the Azure OpenAI service (eg. https://<resource-name>.<region>.api.cognitive.microsoft.com/)",
+        "Client Id":
+            "Unique identifier for the application when using Azure Active Directory. Can typically be found in App Registrations > [application].",
+        "Client Secret":
+            "Password or key that app uses to authenticate with Azure Active Directory. Can typically be found in App Registrations > [application] > Certificates & Secrets",
+        "Tenant Id":
+            "Identifier of instance where the app and resources reside. Can typically be found in Azure Active Directory > Overview > Directory ID",
+        "Subscription Id":
+            "Identifier of user's Azure subscription. Can typically be found in Azure Portal > Subscriptions > Overview.",
+        "Resource Group":
+            "Container that holds related Azure resources. Can typically be found in Azure Portal > Resource Groups > [OpenAI Resource Group] > Overview",
+    },
+};

--- a/ui/admin/app/components/model/shared/DefaultModelAliasForm.tsx
+++ b/ui/admin/app/components/model/shared/DefaultModelAliasForm.tsx
@@ -237,7 +237,9 @@ export function DefaultModelAliasFormDialog({
                 </DialogHeader>
 
                 <DialogDescription>
-                    Set the default model for each usage.
+                    When no model is specified, a default model is used for
+                    creating a new agent, workflow, or working with some tools,
+                    etc. Select your default models for the usage types below.
                 </DialogDescription>
 
                 <DefaultModelAliasForm onSuccess={() => setOpen(false)} />

--- a/ui/admin/app/routes/_auth.model-providers.tsx
+++ b/ui/admin/app/routes/_auth.model-providers.tsx
@@ -2,6 +2,8 @@ import { CircleAlertIcon } from "lucide-react";
 import useSWR, { preload } from "swr";
 
 import { ModelProvider } from "~/lib/model/modelProviders";
+import { DefaultModelAliasApiService } from "~/lib/service/api/defaultModelAliasApiService";
+import { ModelApiService } from "~/lib/service/api/modelApiService";
 import { ModelProviderApiService } from "~/lib/service/api/modelProviderApiService";
 
 import { TypographyH2 } from "~/components/Typography";
@@ -11,11 +13,17 @@ import { DefaultModelAliasFormDialog } from "~/components/model/shared/DefaultMo
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 
 export async function clientLoader() {
-    await preload(
-        ModelProviderApiService.getModelProviders.key(),
-        ModelProviderApiService.getModelProviders
-    );
-
+    await Promise.all([
+        preload(ModelApiService.getModels.key(), ModelApiService.getModels),
+        preload(
+            ModelProviderApiService.getModelProviders.key(),
+            ModelProviderApiService.getModelProviders
+        ),
+        preload(
+            DefaultModelAliasApiService.getAliases.key(),
+            DefaultModelAliasApiService.getAliases
+        ),
+    ]);
     return null;
 }
 
@@ -59,24 +67,27 @@ export default function ModelProviders() {
     return (
         <div>
             <div className="relative space-y-10 px-8 pb-8">
-                <div className="sticky top-0 bg-background pt-8 flex items-center justify-between">
-                    <TypographyH2 className="mb-0 pb-0">
-                        Model Providers
-                    </TypographyH2>
-                    <DefaultModelAliasFormDialog disabled={!configured} />
+                <div className="sticky top-0 bg-background pt-8 flex flex-col gap-4">
+                    <div className="flex items-center justify-between">
+                        <TypographyH2 className="mb-0 pb-0">
+                            Model Providers
+                        </TypographyH2>
+                        <DefaultModelAliasFormDialog disabled={!configured} />
+                    </div>
+                    {configured ? null : (
+                        <Alert variant="default">
+                            <CircleAlertIcon className="w-4 h-4 !text-warning" />
+                            <AlertTitle>
+                                No Model Providers Configured!
+                            </AlertTitle>
+                            <AlertDescription>
+                                To use Otto&apos;s features, you&apos;ll need to
+                                set up a Model Provider. Select and configure
+                                one below to get started!
+                            </AlertDescription>
+                        </Alert>
+                    )}
                 </div>
-
-                {configured ? null : (
-                    <Alert variant="default">
-                        <CircleAlertIcon className="w-4 h-4 !text-warning" />
-                        <AlertTitle>No Model Providers Configured!</AlertTitle>
-                        <AlertDescription>
-                            To use Otto&apos;s features, you&apos;ll need to set
-                            up a Model Provider. Select and configure one below
-                            to get started!
-                        </AlertDescription>
-                    </Alert>
-                )}
 
                 <div className="h-full flex flex-col gap-8 overflow-hidden">
                     <ModelProviderList modelProviders={modelProviders ?? []} />


### PR DESCRIPTION
https://github.com/user-attachments/assets/ff2f6bfd-6fcc-4606-a906-9937e3eeb3ab

* view models from a Model Provider. After configuring a Model Provider, gear shows on top right
* added helper text for Azure and Ollama for some inputs that need info to help fill out

<img width="526" alt="Screenshot 2024-12-06 at 8 37 36 AM" src="https://github.com/user-attachments/assets/afbb38a7-58b9-4da0-a441-113b9285cf5c">

* added helper text for required inputs that may require more context (ex. Ollama & Azure OpenAI Model Provider required configurations)

For context, after discussing with Will & Craig, it was decided that it made more sense to view the models from a Model Provider. This PR adds that in but there may be a follow-up of:

* removing the Models page
* turning the delete into a disable toggle switch. disabling means: If a model is disabled, then that means the model is not usable period (Add a warning that the agents/etc could break with this being broken)
* disable instead of deleting a model
* add changing usage as a dropdown in the table row for the models