### PR TITLE
fix: waiting for modelProvider models to load before showing default model selection

### DIFF
--- a/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
@@ -32,11 +32,9 @@ export function ModelProviderConfigure({
     const [loadingModelProviderId, setLoadingModelProviderId] = useState("");
 
     const getLoadingModelProviderModels = useSWR(
-        loadingModelProviderId
-            ? ModelProviderApiService.getModelProviderById.key(
-                  loadingModelProviderId
-              )
-            : null,
+        ModelProviderApiService.getModelProviderById.key(
+            loadingModelProviderId
+        ),
         ({ modelProviderId }) =>
             ModelProviderApiService.getModelProviderById(modelProviderId),
         {

--- a/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import useSWR from "swr";
 
 import { ModelProvider, ModelProviderConfig } from "~/lib/model/modelProviders";
@@ -29,6 +29,34 @@ export function ModelProviderConfigure({
     const [showDefaultModelAliasForm, setShowDefaultModelAliasForm] =
         useState(false);
 
+    const [loadingModelProviderId, setLoadingModelProviderId] = useState("");
+
+    const getLoadingModelProviderModels = useSWR(
+        loadingModelProviderId
+            ? ModelProviderApiService.getModelProviderById.key(
+                  loadingModelProviderId
+              )
+            : null,
+        ({ modelProviderId }) =>
+            ModelProviderApiService.getModelProviderById(modelProviderId),
+        {
+            revalidateOnFocus: false,
+            refreshInterval: 2000,
+        }
+    );
+
+    useEffect(() => {
+        if (!loadingModelProviderId) return;
+
+        const { isLoading, data } = getLoadingModelProviderModels;
+        if (isLoading) return;
+
+        if (data?.modelsBackPopulated) {
+            setShowDefaultModelAliasForm(true);
+            setLoadingModelProviderId("");
+        }
+    }, [getLoadingModelProviderModels, loadingModelProviderId]);
+
     const handleDone = () => {
         setDialogIsOpen(false);
         setShowDefaultModelAliasForm(false);
@@ -49,8 +77,16 @@ export function ModelProviderConfigure({
                 Configure Model Provider
             </DialogDescription>
 
-            <DialogContent className="p-0 gap-0">
-                {showDefaultModelAliasForm ? (
+            <DialogContent
+                className="p-0 gap-0"
+                hideCloseButton={loadingModelProviderId !== ""}
+            >
+                {loadingModelProviderId ? (
+                    <div className="flex items-center justify-center gap-1 p-2">
+                        <LoadingSpinner /> Loading {modelProvider.name}{" "}
+                        Models...
+                    </div>
+                ) : showDefaultModelAliasForm ? (
                     <div className="p-6">
                         <DialogHeader>
                             <DialogTitle className="flex items-center gap-2 pb-4">
@@ -62,7 +98,9 @@ export function ModelProviderConfigure({
                 ) : (
                     <ModelProviderConfigureContent
                         modelProvider={modelProvider}
-                        onSuccess={() => setShowDefaultModelAliasForm(true)}
+                        onSuccess={() =>
+                            setLoadingModelProviderId(modelProvider.id)
+                        }
                     />
                 )}
             </DialogContent>

--- a/ui/admin/app/components/model-providers/ModelProviderModels.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderModels.tsx
@@ -75,7 +75,7 @@ export function ModelProvidersModels({ modelProvider }: ModelsConfigureProps) {
                     <DataTable
                         columns={getColumns()}
                         data={models}
-                        sort={[{ id: "name", desc: false }]}
+                        sort={[{ id: "usage", desc: true }]}
                     />
                 </ScrollArea>
             </DialogContent>
@@ -88,16 +88,17 @@ export function ModelProvidersModels({ modelProvider }: ModelsConfigureProps) {
                 id: "name",
                 header: "Model",
             }),
-            columnHelper.display({
-                id: "usage",
-                header: "Usage",
-                cell: ({ row }) =>
-                    getModelUsageLabel(row.original.usage) ? (
-                        <Badge variant="outline">
-                            {getModelUsageLabel(row.original.usage)}
-                        </Badge>
-                    ) : null,
-            }),
+            columnHelper.accessor(
+                (model) => getModelUsageLabel(model.usage) || "",
+                {
+                    id: "usage",
+                    header: "Usage",
+                    cell: ({ getValue }) =>
+                        getValue() ? (
+                            <Badge variant="outline">{getValue()}</Badge>
+                        ) : null,
+                }
+            ),
             columnHelper.display({
                 id: "actions",
                 cell: ({ row }) => (

--- a/ui/admin/app/components/model-providers/ModelProviderModels.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderModels.tsx
@@ -75,7 +75,7 @@ export function ModelProvidersModels({ modelProvider }: ModelsConfigureProps) {
                     <DataTable
                         columns={getColumns()}
                         data={models}
-                        sort={[{ id: "id", desc: true }]}
+                        sort={[{ id: "name", desc: false }]}
                     />
                 </ScrollArea>
             </DialogContent>
@@ -84,18 +84,19 @@ export function ModelProvidersModels({ modelProvider }: ModelsConfigureProps) {
 
     function getColumns(): ColumnDef<Model, string>[] {
         return [
-            columnHelper.accessor((model) => model.id, {
-                id: "id",
+            columnHelper.accessor((model) => model.name, {
+                id: "name",
                 header: "Model",
             }),
             columnHelper.display({
                 id: "usage",
                 header: "Usage",
-                cell: ({ row }) => (
-                    <Badge variant="outline">
-                        {getModelUsageLabel(row.original.usage)}
-                    </Badge>
-                ),
+                cell: ({ row }) =>
+                    getModelUsageLabel(row.original.usage) ? (
+                        <Badge variant="outline">
+                            {getModelUsageLabel(row.original.usage)}
+                        </Badge>
+                    ) : null,
             }),
             columnHelper.display({
                 id: "actions",

--- a/ui/admin/app/components/model/shared/DefaultModelAliasForm.tsx
+++ b/ui/admin/app/components/model/shared/DefaultModelAliasForm.tsx
@@ -14,6 +14,7 @@ import {
 import { DefaultModelAliasApiService } from "~/lib/service/api/defaultModelAliasApiService";
 import { ModelApiService } from "~/lib/service/api/modelApiService";
 
+import { TypographyP } from "~/components/Typography";
 import { Button } from "~/components/ui/button";
 import {
     Dialog,
@@ -208,9 +209,9 @@ export function DefaultModelAliasForm({
         if (!modelOptions) {
             if (!defaultModel)
                 return (
-                    <div className="p-2 text-sm text-muted-foreground">
+                    <TypographyP className="p-2 text-muted-foreground">
                         No Models Available.
-                    </div>
+                    </TypographyP>
                 );
             return <SelectItem value={defaultModel}>{defaultModel}</SelectItem>;
         }

--- a/ui/admin/app/components/model/shared/DefaultModelAliasForm.tsx
+++ b/ui/admin/app/components/model/shared/DefaultModelAliasForm.tsx
@@ -206,7 +206,12 @@ export function DefaultModelAliasForm({
         defaultModel: string
     ) {
         if (!modelOptions) {
-            if (!defaultModel) return null;
+            if (!defaultModel)
+                return (
+                    <div className="p-2 text-sm text-muted-foreground">
+                        No Models Available.
+                    </div>
+                );
             return <SelectItem value={defaultModel}>{defaultModel}</SelectItem>;
         }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/a1c84366-7ecc-4576-b44f-ca48ceac68de

* adds polling to wait for models to be back populated after configuring

Also included small fixes:
* No Models Available when no options to select in default model input dropdown
* do not show empty badge when usage isn't set for back populated models
* show name instead of id in table when viewing model provider's models