### PR TITLE
Fix: Add agent.status.textEmbedding and set it in controller

### DIFF
--- a/pkg/api/handlers/agent.go
+++ b/pkg/api/handlers/agent.go
@@ -106,16 +106,6 @@ func convertAgent(agent v1.Agent, req api.Context) (*types.Agent, error) {
 		links = []string{"invoke", req.APIBaseURL + "/invoke/" + alias}
 	}
 
-	var embeddingModel string
-	if len(agent.Status.KnowledgeSetNames) > 0 {
-		var ks v1.KnowledgeSet
-		if err := req.Get(&ks, agent.Status.KnowledgeSetNames[0]); err == nil {
-			embeddingModel = ks.Status.TextEmbeddingModel
-		} else {
-			log.Warnf("failed to get KnowledgeSet %q for agent %q: %v", agent.Status.KnowledgeSetNames[0], agent.Name, err)
-		}
-	}
-
 	var aliasAssigned *bool
 	if agent.Generation == agent.Status.AliasObservedGeneration {
 		aliasAssigned = &agent.Status.AliasAssigned
@@ -126,7 +116,7 @@ func convertAgent(agent v1.Agent, req api.Context) (*types.Agent, error) {
 		AgentManifest:      agent.Spec.Manifest,
 		AliasAssigned:      aliasAssigned,
 		AuthStatus:         agent.Status.AuthStatus,
-		TextEmbeddingModel: embeddingModel,
+		TextEmbeddingModel: agent.Status.TextEmbeddingModel,
 	}, nil
 }
 

--- a/pkg/controller/handlers/knowledgeset/knowledgeset.go
+++ b/pkg/controller/handlers/knowledgeset/knowledgeset.go
@@ -166,6 +166,25 @@ func (h *Handler) SetEmbeddingModel(req router.Request, _ router.Response) error
 	return nil
 }
 
+func (h *Handler) UpdateAgentTextEmbedding(req router.Request, _ router.Response) error {
+	ks := req.Object.(*v1.KnowledgeSet)
+
+	if ks.Spec.AgentName == "" {
+		return nil
+	}
+
+	var agent v1.Agent
+	if err := req.Get(&agent, req.Namespace, ks.Spec.AgentName); err != nil {
+		return err
+	}
+	if agent.Status.TextEmbeddingModel != ks.Status.TextEmbeddingModel {
+		agent.Status.TextEmbeddingModel = ks.Status.TextEmbeddingModel
+		return req.Client.Status().Update(req.Ctx, &agent)
+	}
+
+	return nil
+}
+
 func (h *Handler) CreateWorkspace(req router.Request, _ router.Response) error {
 	ks := req.Object.(*v1.KnowledgeSet)
 

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -100,6 +100,7 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.KnowledgeSet{}).HandlerFunc(knowledgeset.CreateWorkspace)
 	root.Type(&v1.KnowledgeSet{}).HandlerFunc(knowledgeset.CheckHasContent)
 	root.Type(&v1.KnowledgeSet{}).HandlerFunc(knowledgeset.SetEmbeddingModel)
+	root.Type(&v1.KnowledgeSet{}).HandlerFunc(knowledgeset.UpdateAgentTextEmbedding)
 
 	// Webhooks
 	root.Type(&v1.Webhook{}).HandlerFunc(cleanup.Cleanup)

--- a/pkg/storage/apis/otto.otto8.ai/v1/agent.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/agent.go
@@ -77,6 +77,7 @@ type AgentStatus struct {
 	AliasAssigned           bool                                     `json:"aliasAssigned,omitempty"`
 	AuthStatus              map[string]types.OAuthAppLoginAuthStatus `json:"authStatus,omitempty"`
 	AliasObservedGeneration int64                                    `json:"aliasProcessed,omitempty"`
+	TextEmbeddingModel      string                                   `json:"textEmbeddingModel,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -4403,6 +4403,12 @@ func schema_storage_apis_ottootto8ai_v1_AgentStatus(ref common.ReferenceCallback
 							Format: "int64",
 						},
 					},
+					"textEmbeddingModel": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
We are making multiple requests in agent list call because it needs to fetch the knowledge set for each agent to get textEmbeddingModel. The call becomes extremely slow when database is on load or ingestion is running. So add the the embedding field in agent.status directly and set it in controller to avoid extra api calls when listing agent. 