### PR TITLE
feat: sort models by name in default model dropdowns

### DIFF
--- a/apiclient/types/model.go
+++ b/apiclient/types/model.go
@@ -12,7 +12,7 @@ type ModelManifest struct {
 	ModelProvider string     `json:"modelProvider,omitempty"`
 	Alias         string     `json:"alias,omitempty"`
 	Active        bool       `json:"active"`
-	Usage         ModelUsage `json:"usage,omitempty"`
+	Usage         ModelUsage `json:"usage"`
 }
 
 type ModelList List[Model]

--- a/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
@@ -78,7 +78,7 @@ export function ModelProviderConfigure({
             </DialogDescription>
 
             <DialogContent
-                className="p-0 gap-0"
+                className="p-0 gap-0 max-w-2xl"
                 hideCloseButton={loadingModelProviderId !== ""}
             >
                 {loadingModelProviderId ? (

--- a/ui/admin/app/components/model/DefaultModelAliasForm.tsx
+++ b/ui/admin/app/components/model/DefaultModelAliasForm.tsx
@@ -296,7 +296,7 @@ export function DefaultModelAliasFormDialog({
                 <Button disabled={disabled}>Set Default Models</Button>
             </DialogTrigger>
 
-            <DialogContent>
+            <DialogContent className="max-w-2xl">
                 <DialogHeader>
                     <DialogTitle>Default Model Aliases</DialogTitle>
                 </DialogHeader>

--- a/ui/admin/app/components/model/constants.ts
+++ b/ui/admin/app/components/model/constants.ts
@@ -1,0 +1,12 @@
+import { ModelAlias } from "~/lib/model/models";
+
+export const SUGGESTED_MODEL_SELECTIONS: Record<
+    ModelAlias,
+    string | undefined
+> = {
+    [ModelAlias.Llm]: "gpt-4o",
+    [ModelAlias.LlmMini]: "gpt-4o-mini",
+    [ModelAlias.TextEmbedding]: "text-embedding-3-large",
+    [ModelAlias.ImageGeneration]: "dall-e-3",
+    [ModelAlias.Vision]: "gpt-4o",
+};

--- a/ui/admin/app/lib/model/defaultModelAliases.ts
+++ b/ui/admin/app/lib/model/defaultModelAliases.ts
@@ -1,5 +1,7 @@
+import { ModelAlias } from "~/lib/model/models";
+
 export type DefaultModelAliasBase = {
-    alias: string;
+    alias: ModelAlias;
     model: string;
 };
 

--- a/ui/admin/app/lib/model/models.ts
+++ b/ui/admin/app/lib/model/models.ts
@@ -59,6 +59,21 @@ export const ModelAliasToUsageMap = {
     [ModelAlias.Vision]: ModelUsage.Vision,
 } as const;
 
+export function filterModelsByUsage(
+    models: Model[],
+    usages: ModelUsage | ModelUsage[],
+    sort = (a: Model, b: Model) => (b.name ?? "").localeCompare(a.name ?? "")
+) {
+    const _usages = Array.isArray(usages) ? usages : [usages];
+
+    // Vision models are LLMs
+    if (_usages.includes(ModelUsage.Vision)) {
+        _usages.push(ModelUsage.LLM);
+    }
+
+    return models.filter((model) => _usages.includes(model.usage)).sort(sort);
+}
+
 export type ModelManifest = {
     name?: string;
     targetModel?: string;


### PR DESCRIPTION
<img width="813" alt="Screenshot 2024-12-06 at 4 00 35 PM" src="https://github.com/user-attachments/assets/9d39afa5-0bdd-4bbf-966b-a706a4e90c50">

<img width="826" alt="Screenshot 2024-12-06 at 4 01 16 PM" src="https://github.com/user-attachments/assets/583904bd-920d-4a2c-9d59-377a6a646a55">

<img width="693" alt="Screenshot 2024-12-06 at 5 27 20 PM" src="https://github.com/user-attachments/assets/af4851a4-1cf5-4f8e-809a-c4a4cb535fd8">

 - sorts models by name in default model dropdowns
- adds an "Other" group to dropdowns for models that don't have a usage
- ensures that backend always returns a value for model usage
- apply suggested models to default models form after configuration

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>