### PR TITLE
Fix: Make workflow thread link clickable

### DIFF
--- a/ui/admin/app/routes/_auth.workflows._index.tsx
+++ b/ui/admin/app/routes/_auth.workflows._index.tsx
@@ -80,6 +80,9 @@ export default function Workflows() {
                         columns={getColumns()}
                         data={getWorkflows.data || []}
                         sort={[{ id: "created", desc: true }]}
+                        disableClickPropagation={(cell) =>
+                            cell.id.includes("action")
+                        }
                         onRowClick={(row) => {
                             navigate(
                                 $path("/workflows/:workflow", {


### PR DESCRIPTION
Couldn't click the Threads link on the workflow table because the row
click was getting in the way.

Signed-off-by: Craig Jellick <craig@acorn.io>
