### PR TITLE
enhance: support syntax for sensitive model provider params

### DIFF
--- a/apiclient/types/modelprovider.go
+++ b/apiclient/types/modelprovider.go
@@ -12,11 +12,12 @@ type ModelProviderManifest struct {
 }
 
 type ModelProviderStatus struct {
-	Icon                            string   `json:"icon,omitempty"`
-	Configured                      bool     `json:"configured"`
-	ModelsBackPopulated             *bool    `json:"modelsBackPopulated,omitempty"`
-	RequiredConfigurationParameters []string `json:"requiredConfigurationParameters,omitempty"`
-	MissingConfigurationParameters  []string `json:"missingConfigurationParameters,omitempty"`
+	Icon                             string   `json:"icon,omitempty"`
+	Configured                       bool     `json:"configured"`
+	ModelsBackPopulated              *bool    `json:"modelsBackPopulated,omitempty"`
+	RequiredConfigurationParameters  []string `json:"requiredConfigurationParameters,omitempty"`
+	MissingConfigurationParameters   []string `json:"missingConfigurationParameters,omitempty"`
+	SensitiveConfigurationParameters []string `json:"sensitiveConfigurationParameters,omitempty"`
 }
 
 type ModelProviderList List[ModelProvider]

--- a/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
@@ -131,6 +131,7 @@ export function ModelProviderConfigureContent({
     );
 
     const requiredParameters = modelProvider.requiredConfigurationParameters;
+    const sensitiveParameters = modelProvider.sensitiveConfigurationParameters;
     const parameters = revealModelProvider.data;
 
     return (
@@ -165,6 +166,7 @@ export function ModelProviderConfigureContent({
                     onSuccess={onSuccess}
                     parameters={parameters ?? {}}
                     requiredParameters={requiredParameters ?? []}
+                    sensitiveParameters={sensitiveParameters ?? []}
                 />
             )}
         </>

--- a/ui/admin/app/components/model-providers/ModelProviderForm.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderForm.tsx
@@ -104,11 +104,13 @@ export function ModelProviderForm({
     onSuccess,
     parameters,
     requiredParameters,
+    sensitiveParameters,
 }: {
     modelProvider: ModelProvider;
     onSuccess: () => void;
     parameters: ModelProviderConfig;
     requiredParameters: string[];
+    sensitiveParameters: string[];
 }) {
     const fetchAvailableModels = useAsync(
         ModelApiService.getAvailableModelsByProvider,
@@ -223,7 +225,13 @@ export function ModelProviderForm({
                                             )}
                                             control={form.control}
                                             name={`requiredConfigParams.${i}.value`}
-                                            type="password"
+                                            type={
+                                                sensitiveParameters.includes(
+                                                    field.name
+                                                )
+                                                    ? "password"
+                                                    : "text"
+                                            }
                                             classNames={{
                                                 wrapper:
                                                     "flex-auto bg-background",

--- a/ui/admin/app/components/ui/input.tsx
+++ b/ui/admin/app/components/ui/input.tsx
@@ -1,15 +1,20 @@
 import { type VariantProps, cva } from "class-variance-authority";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "~/lib/utils";
 
+import { buttonVariants } from "~/components/ui/button";
+
 const inputVariants = cva(
-    "flex h-9 w-full rounded-md px-3 bg-transparent border border-input text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+    cn(
+        "flex items-center h-9 w-full rounded-md bg-transparent border border-input text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground has-[:focus-visible]:ring-1 has-[:focus-visible]:ring-ring has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50"
+    ),
     {
         variants: {
             variant: {
                 default: "",
-                ghost: "shadow-none cursor-pointer hover:border-primary px-0 mb-0 font-bold outline-none border-transparent focus:border-primary",
+                ghost: "shadow-none cursor-pointer hover:border-primary px-0 mb-0 font-bold outline-none border-transparent has-[:focus-visible]:border-primary",
             },
         },
         defaultVariants: {
@@ -20,18 +25,53 @@ const inputVariants = cva(
 
 export interface InputProps
     extends React.InputHTMLAttributes<HTMLInputElement>,
-        VariantProps<typeof inputVariants> {}
+        VariantProps<typeof inputVariants> {
+    disableToggle?: boolean;
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-    ({ className, variant, type, ...props }, ref) => {
+    ({ className, variant, type, disableToggle = false, ...props }, ref) => {
+        const isPassword = type === "password";
+        const [isVisible, setIsVisible] = React.useState(false);
+
+        const internalType = isPassword
+            ? isVisible && !disableToggle
+                ? "text"
+                : "password"
+            : type;
+
+        const toggleVisible = React.useCallback(
+            () => setIsVisible((prev) => !prev),
+            []
+        );
+
         return (
-            <input
-                type={type}
-                data-1p-ignore={type !== "password"}
-                className={cn(inputVariants({ variant, className }))}
-                ref={ref}
-                {...props}
-            />
+            <div className={cn(inputVariants({ variant, className }))}>
+                <input
+                    type={internalType}
+                    data-1p-ignore={!isPassword}
+                    className={cn(
+                        "w-full p-3 bg-transparent border-none focus-visible:border-none focus-visible:outline-none rounded-full"
+                    )}
+                    ref={ref}
+                    {...props}
+                />
+
+                {isPassword && !disableToggle && (
+                    <button
+                        type="button"
+                        onClick={toggleVisible}
+                        className={buttonVariants({
+                            variant: "ghost",
+                            size: "icon",
+                            shape: "default",
+                            className: "min-h-full !h-full rounded-s-none",
+                        })}
+                    >
+                        {!isVisible ? <EyeIcon /> : <EyeOffIcon />}
+                    </button>
+                )}
+            </div>
         );
     }
 );

--- a/ui/admin/app/lib/model/modelProviders.ts
+++ b/ui/admin/app/lib/model/modelProviders.ts
@@ -6,6 +6,7 @@ export type ModelProviderStatus = {
     icon?: string;
     requiredConfigurationParameters?: string[];
     missingConfigurationParameters?: string[];
+    sensitiveConfigurationParameters?: string[];
 };
 
 export type ModelProvider = EntityMeta &


### PR DESCRIPTION
Add support for specifying sensitive model provider parameters by adding a `!` prefix to the parameter name in the `Metadata: envVars` list in the provider's tool definition.

Marking a parameter as sensitive will hide the parameter's value in the model provider config form.

e.g. Marking the `OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_SECRET` as sensitive

```yaml
Name: Azure OpenAI
Description: Model provider for Azure OpenAI hosted models
Metadata: envVars: OTTO8_AZURE_OPENAI_MODEL_PROVIDER_ENDPOINT,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_ID,!OTTO8_AZURE_OPENAI_MODEL_PROVIDER_CLIENT_SECRET,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_TENANT_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_SUBSCRIPTION_ID,OTTO8_AZURE_OPENAI_MODEL_PROVIDER_RESOURCE_GROUP
Model Provider: true
Credential: ../model-provider-credential as azure-openai-model-provider
```

![sensitive-params](https://github.com/user-attachments/assets/36eb6a71-350f-4ccf-bfe7-1b64577105cc)


