### PR TITLE
Fix: Add include/exclude list first before approving files

### DIFF
--- a/ui/admin/app/components/knowledge/FileTree.tsx
+++ b/ui/admin/app/components/knowledge/FileTree.tsx
@@ -110,13 +110,6 @@ export default function FileTreeNode({
         excluded && !source.filePathPrefixExclude?.includes(node.path);
 
     const toggleIncludeExcludeList = async () => {
-        // We should manually approve/unapprove all files in the folder at once so that we don't rely on backend reconciliation logic as it will cause delay in updating the UI.
-        try {
-            await onApproveFile(!included, node);
-        } catch (e) {
-            console.error("failed to approve files", e);
-        }
-
         // After files are approved/unapproved, we need to update the include/exclude list so that new files will be included/excluded from future syncs.
         let filePathPrefixInclude = source.filePathPrefixInclude;
         let filePathPrefixExclude = source.filePathPrefixExclude;
@@ -145,6 +138,13 @@ export default function FileTreeNode({
             filePathPrefixInclude,
             filePathPrefixExclude,
         });
+
+        // We should manually approve/unapprove all files in the folder at once so that we don't rely on backend reconciliation logic as it will cause delay in updating the UI.
+        try {
+            await onApproveFile(!included, node);
+        } catch (e) {
+            console.error("failed to approve files", e);
+        }
     };
 
     return (


### PR DESCRIPTION
When adding/excluding files, we approve/unapprove individual files first and then add include/exclude list for backend reconcilation. Since approving individual files takes some time, if getting interupted, the backedn include/exclude list will never be added. So moving the logic up to add include/exclude list first before approving/unapproving individual files.

https://github.com/otto8-ai/otto8/issues/822