### PR TITLE
enhance: if no default text-embedding set, disable knowledge for agent/workflows

### DIFF
--- a/ui/admin/app/components/composed/WarningAlert.tsx
+++ b/ui/admin/app/components/composed/WarningAlert.tsx
@@ -7,7 +7,7 @@ export function WarningAlert({
     description,
 }: {
     title: string;
-    description: string | React.ReactNode;
+    description: React.ReactNode;
 }) {
     return (
         <Alert variant="default">

--- a/ui/admin/app/components/composed/WarningAlert.tsx
+++ b/ui/admin/app/components/composed/WarningAlert.tsx
@@ -1,0 +1,19 @@
+import { CircleAlertIcon } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
+
+export function WarningAlert({
+    title,
+    description,
+}: {
+    title: string;
+    description: string | React.ReactNode;
+}) {
+    return (
+        <Alert variant="default">
+            <CircleAlertIcon className="w-4 h-4 !text-warning" />
+            <AlertTitle>{title}</AlertTitle>
+            <AlertDescription>{description}</AlertDescription>
+        </Alert>
+    );
+}

--- a/ui/admin/app/routes/_auth.agents.$agent.tsx
+++ b/ui/admin/app/routes/_auth.agents.$agent.tsx
@@ -6,8 +6,10 @@ import {
 } from "@remix-run/react";
 import { useCallback } from "react";
 import { $path } from "remix-routes";
+import { preload } from "swr";
 
 import { AgentService } from "~/lib/service/api/agentService";
+import { DefaultModelAliasApiService } from "~/lib/service/api/defaultModelAliasApiService";
 import { RouteQueryParams, RouteService } from "~/lib/service/routeService";
 import { noop } from "~/lib/utils";
 
@@ -36,6 +38,11 @@ export const clientLoader = async ({
     if (!agentId) {
         throw redirect("/agents");
     }
+
+    await preload(
+        DefaultModelAliasApiService.getAliases.key(),
+        DefaultModelAliasApiService.getAliases
+    );
 
     // preload the agent
     const agent = await AgentService.getAgentById(agentId).catch(noop);

--- a/ui/admin/app/routes/_auth.model-providers.tsx
+++ b/ui/admin/app/routes/_auth.model-providers.tsx
@@ -1,4 +1,3 @@
-import { CircleAlertIcon } from "lucide-react";
 import useSWR, { preload } from "swr";
 
 import { ModelProvider } from "~/lib/model/modelProviders";
@@ -7,10 +6,10 @@ import { ModelApiService } from "~/lib/service/api/modelApiService";
 import { ModelProviderApiService } from "~/lib/service/api/modelProviderApiService";
 
 import { TypographyH2 } from "~/components/Typography";
+import { WarningAlert } from "~/components/composed/WarningAlert";
 import { ModelProviderList } from "~/components/model-providers/ModelProviderLists";
 import { CommonModelProviderIds } from "~/components/model-providers/constants";
 import { DefaultModelAliasFormDialog } from "~/components/model/DefaultModelAliasForm";
-import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 
 export async function clientLoader() {
     await Promise.all([
@@ -75,17 +74,12 @@ export default function ModelProviders() {
                         <DefaultModelAliasFormDialog disabled={!configured} />
                     </div>
                     {configured ? null : (
-                        <Alert variant="default">
-                            <CircleAlertIcon className="w-4 h-4 !text-warning" />
-                            <AlertTitle>
-                                No Model Providers Configured!
-                            </AlertTitle>
-                            <AlertDescription>
-                                To use Otto&apos;s features, you&apos;ll need to
+                        <WarningAlert
+                            title="No Model Providers Configured!"
+                            description="To use Otto's features, you'll need to
                                 set up a Model Provider. Select and configure
-                                one below to get started!
-                            </AlertDescription>
-                        </Alert>
+                                one below to get started!"
+                        />
                     )}
                 </div>
 


### PR DESCRIPTION
<img width="691" alt="Screenshot 2024-12-13 at 9 44 45 AM" src="https://github.com/user-attachments/assets/df61aee5-02fc-43a9-a627-fbd77ae7922f" />

* disables Knowledge description & Add Knowledge button if default text-embedding isn't set
* adds Alert to notify user why it's disabled