### PR TITLE
Chore/admin/update-breadcrumb-logic

### DIFF
--- a/ui/admin/app/components/header/HeaderNav.tsx
+++ b/ui/admin/app/components/header/HeaderNav.tsx
@@ -1,11 +1,8 @@
-import { Link } from "@remix-run/react";
+import { Link, UIMatch, useLocation, useMatches } from "@remix-run/react";
+import React from "react";
 import { $path } from "remix-routes";
-import useSWR from "swr";
 
-import { AgentService } from "~/lib/service/api/agentService";
-import { ThreadsService } from "~/lib/service/api/threadsService";
-import { WebhookApiService } from "~/lib/service/api/webhookApiService";
-import { WorkflowService } from "~/lib/service/api/workflowService";
+import { RouteHandle } from "~/lib/service/routeHandles";
 import { cn } from "~/lib/utils";
 
 import { DarkModeToggle } from "~/components/DarkModeToggle";
@@ -19,7 +16,6 @@ import {
 } from "~/components/ui/breadcrumb";
 import { SidebarTrigger } from "~/components/ui/sidebar";
 import { UserMenu } from "~/components/user/UserMenu";
-import { useUnknownPathParams } from "~/hooks/useRouteInfo";
 
 export function HeaderNav() {
     const headerHeight = "h-[60px]";
@@ -36,7 +32,7 @@ export function HeaderNav() {
                     <div className="flex-grow flex justify-start items-center p-4">
                         <SidebarTrigger className="h-4 w-4" />
                         <div className="border-r h-4 mx-4" />
-                        <RouteBreadcrumbs />
+                        <RouteBreadcrumbHandles />
                     </div>
 
                     <div className="flex items-center justify-center p-4 mr-4">
@@ -49,8 +45,39 @@ export function HeaderNav() {
     );
 }
 
-function RouteBreadcrumbs() {
-    const routeInfo = useUnknownPathParams();
+function RouteBreadcrumbHandles() {
+    const matches = useMatches() as UIMatch<unknown, RouteHandle>[];
+    const location = useLocation();
+    const filtered = matches.filter((match) => match.handle?.breadcrumb);
+
+    const renderItem = (
+        match: UIMatch<unknown, RouteHandle>,
+        isLeaf: boolean
+    ) => {
+        if (!match.handle?.breadcrumb) return;
+
+        return match.handle.breadcrumb(location).map((item, i, arr) => {
+            const withHref = isLeaf && i === arr.length - 1;
+
+            return (
+                <React.Fragment key={`${match.id}-${i}`}>
+                    <BreadcrumbSeparator />
+
+                    <BreadcrumbItem>
+                        {withHref ? (
+                            <BreadcrumbPage>{item.content}</BreadcrumbPage>
+                        ) : (
+                            <BreadcrumbLink asChild>
+                                <Link to={item.href ?? match.pathname}>
+                                    {item.content}
+                                </Link>
+                            </BreadcrumbLink>
+                        )}
+                    </BreadcrumbItem>
+                </React.Fragment>
+            );
+        });
+    };
 
     return (
         <Breadcrumb>
@@ -60,196 +87,11 @@ function RouteBreadcrumbs() {
                         <Link to={$path("/")}>Home</Link>
                     </BreadcrumbLink>
                 </BreadcrumbItem>
-                <BreadcrumbSeparator />
 
-                {routeInfo?.path === "/agents/:agent" && (
-                    <>
-                        <BreadcrumbItem>
-                            <BreadcrumbLink asChild>
-                                <Link to={$path("/agents")}>Agents</Link>
-                            </BreadcrumbLink>
-                        </BreadcrumbItem>
-                        <BreadcrumbSeparator />
-                        <BreadcrumbItem>
-                            <BreadcrumbPage>
-                                <AgentName
-                                    agentId={routeInfo.pathParams.agent || ""}
-                                />
-                            </BreadcrumbPage>
-                        </BreadcrumbItem>
-                    </>
-                )}
-
-                {routeInfo?.path === "/agents" && (
-                    <BreadcrumbItem>
-                        <BreadcrumbPage>Agents</BreadcrumbPage>
-                    </BreadcrumbItem>
-                )}
-
-                {routeInfo?.path === "/threads" && (
-                    <>
-                        {routeInfo.query?.from && (
-                            <>
-                                <BreadcrumbItem>
-                                    <BreadcrumbLink asChild>
-                                        {renderThreadFrom(routeInfo.query.from)}
-                                    </BreadcrumbLink>
-                                </BreadcrumbItem>
-
-                                <BreadcrumbSeparator />
-                            </>
-                        )}
-
-                        <BreadcrumbItem>
-                            <BreadcrumbPage>Threads</BreadcrumbPage>
-                        </BreadcrumbItem>
-                    </>
-                )}
-
-                {routeInfo?.path === "/threads/:id" && (
-                    <>
-                        <BreadcrumbItem>
-                            <BreadcrumbLink asChild>
-                                <Link to={$path("/threads")}>Threads</Link>
-                            </BreadcrumbLink>
-                        </BreadcrumbItem>
-                        <BreadcrumbSeparator />
-                        <BreadcrumbItem>
-                            <BreadcrumbPage>
-                                <ThreadName
-                                    threadId={routeInfo.pathParams.id || ""}
-                                />
-                            </BreadcrumbPage>
-                        </BreadcrumbItem>
-                    </>
-                )}
-
-                {routeInfo?.path === "/workflows/:workflow" && (
-                    <>
-                        <BreadcrumbItem>
-                            <BreadcrumbLink asChild>
-                                <Link to={$path("/workflows")}>Workflows</Link>
-                            </BreadcrumbLink>
-                        </BreadcrumbItem>
-                        <BreadcrumbSeparator />
-                        <BreadcrumbItem>
-                            <BreadcrumbPage>
-                                <WorkflowName
-                                    workflowId={
-                                        routeInfo.pathParams.workflow || ""
-                                    }
-                                />
-                            </BreadcrumbPage>
-                        </BreadcrumbItem>
-                    </>
-                )}
-
-                {routeInfo?.path === "/webhooks" && (
-                    <BreadcrumbItem>
-                        <BreadcrumbPage>Webhooks</BreadcrumbPage>
-                    </BreadcrumbItem>
-                )}
-
-                {routeInfo?.path === "/webhooks/create" && (
-                    <>
-                        <BreadcrumbItem>
-                            <BreadcrumbLink asChild>
-                                <Link to={$path("/webhooks")}>Webhooks</Link>
-                            </BreadcrumbLink>
-                        </BreadcrumbItem>
-                        <BreadcrumbSeparator />
-                        <BreadcrumbItem>
-                            <BreadcrumbPage>Create Webhook</BreadcrumbPage>
-                        </BreadcrumbItem>
-                    </>
-                )}
-
-                {routeInfo?.path === "/webhooks/:webhook" && (
-                    <>
-                        <BreadcrumbItem>
-                            <BreadcrumbLink asChild>
-                                <Link to={$path("/webhooks")}>Webhooks</Link>
-                            </BreadcrumbLink>
-                        </BreadcrumbItem>
-                        <BreadcrumbSeparator />
-                        <BreadcrumbItem>
-                            <BreadcrumbPage>
-                                <WebhookName
-                                    webhookId={
-                                        routeInfo.pathParams.webhook || ""
-                                    }
-                                />
-                            </BreadcrumbPage>
-                        </BreadcrumbItem>
-                    </>
-                )}
-
-                {routeInfo?.path === "/tools" && (
-                    <BreadcrumbItem>
-                        <BreadcrumbPage>Tools</BreadcrumbPage>
-                    </BreadcrumbItem>
-                )}
-                {routeInfo?.path === "/users" && (
-                    <BreadcrumbItem>
-                        <BreadcrumbPage>Users</BreadcrumbPage>
-                    </BreadcrumbItem>
-                )}
-                {routeInfo?.path === "/oauth-apps" && (
-                    <BreadcrumbItem>
-                        <BreadcrumbPage>OAuth Apps</BreadcrumbPage>
-                    </BreadcrumbItem>
-                )}
-                {routeInfo?.path === "/model-providers" && (
-                    <BreadcrumbItem>
-                        <BreadcrumbPage>Model Providers</BreadcrumbPage>
-                    </BreadcrumbItem>
+                {filtered.map((match, i, arr) =>
+                    renderItem(match, i === arr.length - 1)
                 )}
             </BreadcrumbList>
         </Breadcrumb>
     );
 }
-
-const renderThreadFrom = (from: "agents" | "workflows" | "users") => {
-    if (from === "agents") return <Link to={$path("/agents")}>Agents</Link>;
-
-    if (from === "workflows")
-        return <Link to={$path("/workflows")}>Workflows</Link>;
-
-    if (from === "users") return <Link to={$path("/users")}>Users</Link>;
-};
-
-const AgentName = ({ agentId }: { agentId: string }) => {
-    const { data: agent } = useSWR(
-        AgentService.getAgentById.key(agentId),
-        ({ agentId }) => AgentService.getAgentById(agentId)
-    );
-
-    return <>{agent?.name || "New Agent"}</>;
-};
-
-const WorkflowName = ({ workflowId }: { workflowId: string }) => {
-    const { data: workflow } = useSWR(
-        WorkflowService.getWorkflowById.key(workflowId),
-        ({ workflowId }) => WorkflowService.getWorkflowById(workflowId)
-    );
-
-    return <>{workflow?.name || "New Workflow"}</>;
-};
-
-const ThreadName = ({ threadId }: { threadId: string }) => {
-    const { data: thread } = useSWR(
-        ThreadsService.getThreadById.key(threadId),
-        ({ threadId }) => ThreadsService.getThreadById(threadId)
-    );
-
-    return <>{thread?.description || threadId}</>;
-};
-
-const WebhookName = ({ webhookId }: { webhookId: string }) => {
-    const { data } = useSWR(
-        WebhookApiService.getWebhookById.key(webhookId),
-        ({ id }) => WebhookApiService.getWebhookById(id)
-    );
-
-    return <>{data?.name || webhookId}</>;
-};

--- a/ui/admin/app/components/model-providers/constants.ts
+++ b/ui/admin/app/components/model-providers/constants.ts
@@ -67,4 +67,7 @@ export const ModelProviderSensitiveFields: Record<string, boolean | undefined> =
 
         // Voyage
         OTTO8_VOYAGE_MODEL_PROVIDER_API_KEY: true,
+
+        // Ollama
+        OTTO8_OLLAMA_MODEL_PROVIDER_HOST: true,
     };

--- a/ui/admin/app/lib/service/routeHandles.ts
+++ b/ui/admin/app/lib/service/routeHandles.ts
@@ -1,0 +1,13 @@
+type BreadcrumbItem = {
+    content?: React.ReactNode;
+    href?: string;
+};
+
+type BreadcrumbProps = {
+    pathname: string;
+    search: string;
+};
+
+export type RouteHandle = {
+    breadcrumb?: (props: BreadcrumbProps) => BreadcrumbItem[];
+};

--- a/ui/admin/app/lib/service/routeService.ts
+++ b/ui/admin/app/lib/service/routeService.ts
@@ -200,4 +200,5 @@ export const RouteService = {
     getUnknownRouteInfo,
     getRouteInfo,
     getQueryParams,
+    getPathParams: $params,
 };

--- a/ui/admin/app/routes/_auth.agents.$agent.tsx
+++ b/ui/admin/app/routes/_auth.agents.$agent.tsx
@@ -2,14 +2,16 @@ import {
     ClientLoaderFunctionArgs,
     redirect,
     useLoaderData,
+    useMatch,
     useNavigate,
 } from "@remix-run/react";
 import { useCallback } from "react";
 import { $path } from "remix-routes";
-import { preload } from "swr";
+import useSWR, { preload } from "swr";
 
 import { AgentService } from "~/lib/service/api/agentService";
 import { DefaultModelAliasApiService } from "~/lib/service/api/defaultModelAliasApiService";
+import { RouteHandle } from "~/lib/service/routeHandles";
 import { RouteQueryParams, RouteService } from "~/lib/service/routeService";
 import { noop } from "~/lib/utils";
 
@@ -92,3 +94,18 @@ export default function ChatAgent() {
         </div>
     );
 }
+
+const AgentBreadcrumb = () => {
+    const match = useMatch("/agents/:agent");
+
+    const { data: agent } = useSWR(
+        AgentService.getAgentById.key(match?.params.agent),
+        ({ agentId }) => AgentService.getAgentById(agentId)
+    );
+
+    return <>{agent?.name || "New Agent"}</>;
+};
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: <AgentBreadcrumb /> }],
+};

--- a/ui/admin/app/routes/_auth.agents.tsx
+++ b/ui/admin/app/routes/_auth.agents.tsx
@@ -1,0 +1,5 @@
+import { RouteHandle } from "~/lib/service/routeHandles";
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: "Agents" }],
+};

--- a/ui/admin/app/routes/_auth.model-providers.tsx
+++ b/ui/admin/app/routes/_auth.model-providers.tsx
@@ -4,6 +4,7 @@ import { ModelProvider } from "~/lib/model/modelProviders";
 import { DefaultModelAliasApiService } from "~/lib/service/api/defaultModelAliasApiService";
 import { ModelApiService } from "~/lib/service/api/modelApiService";
 import { ModelProviderApiService } from "~/lib/service/api/modelProviderApiService";
+import { RouteHandle } from "~/lib/service/routeHandles";
 
 import { TypographyH2 } from "~/components/Typography";
 import { WarningAlert } from "~/components/composed/WarningAlert";
@@ -90,3 +91,7 @@ export default function ModelProviders() {
         </div>
     );
 }
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: "Model Providers" }],
+};

--- a/ui/admin/app/routes/_auth.oauth-apps.tsx
+++ b/ui/admin/app/routes/_auth.oauth-apps.tsx
@@ -1,6 +1,7 @@
 import { preload } from "swr";
 
 import { OauthAppService } from "~/lib/service/api/oauthAppService";
+import { RouteHandle } from "~/lib/service/routeHandles";
 
 import { TypographyH2 } from "~/components/Typography";
 import { OAuthAppList } from "~/components/oauth-apps/OAuthAppList";
@@ -33,3 +34,7 @@ export default function OauthApps() {
         </div>
     );
 }
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: "OAuth Apps" }],
+};

--- a/ui/admin/app/routes/_auth.threads.$id.tsx
+++ b/ui/admin/app/routes/_auth.threads.$id.tsx
@@ -6,6 +6,7 @@ import {
     useMatch,
 } from "@remix-run/react";
 import { ArrowLeftIcon } from "lucide-react";
+import { $path } from "remix-routes";
 
 import { AgentService } from "~/lib/service/api/agentService";
 import { ThreadsService } from "~/lib/service/api/threadsService";
@@ -124,5 +125,8 @@ export default function ChatAgent() {
 const ThreadBreadcrumb = () => useMatch("/threads/:id")?.params.id;
 
 export const handle: RouteHandle = {
-    breadcrumb: () => [{ content: <ThreadBreadcrumb /> }],
+    breadcrumb: () => [
+        { content: "Threads", href: $path("/threads") },
+        { content: <ThreadBreadcrumb /> },
+    ],
 };

--- a/ui/admin/app/routes/_auth.threads.$id.tsx
+++ b/ui/admin/app/routes/_auth.threads.$id.tsx
@@ -3,12 +3,14 @@ import {
     Link,
     redirect,
     useLoaderData,
+    useMatch,
 } from "@remix-run/react";
 import { ArrowLeftIcon } from "lucide-react";
 
 import { AgentService } from "~/lib/service/api/agentService";
 import { ThreadsService } from "~/lib/service/api/threadsService";
 import { WorkflowService } from "~/lib/service/api/workflowService";
+import { RouteHandle } from "~/lib/service/routeHandles";
 import { RouteService } from "~/lib/service/routeService";
 import { noop } from "~/lib/utils";
 
@@ -118,3 +120,9 @@ export default function ChatAgent() {
         </div>
     );
 }
+
+const ThreadBreadcrumb = () => useMatch("/threads/:id")?.params.id;
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: <ThreadBreadcrumb /> }],
+};

--- a/ui/admin/app/routes/_auth.threads._index.tsx
+++ b/ui/admin/app/routes/_auth.threads._index.tsx
@@ -20,6 +20,7 @@ import { AgentService } from "~/lib/service/api/agentService";
 import { ThreadsService } from "~/lib/service/api/threadsService";
 import { UserService } from "~/lib/service/api/userService";
 import { WorkflowService } from "~/lib/service/api/workflowService";
+import { RouteHandle } from "~/lib/service/routeHandles";
 import { RouteQueryParams, RouteService } from "~/lib/service/routeService";
 import { timeSince } from "~/lib/utils";
 
@@ -330,3 +331,30 @@ function ThreadFilters({
 }
 
 const columnHelper = createColumnHelper<Thread>();
+
+const getFromBreadcrumb = (search: string) => {
+    const { from } = RouteService.getQueryParams("/threads", search) || {};
+
+    if (from === "agents")
+        return {
+            content: "Agents",
+            href: $path("/agents"),
+        };
+
+    if (from === "users")
+        return {
+            content: "Users",
+            href: $path("/users"),
+        };
+
+    if (from === "workflows")
+        return {
+            content: "Workflows",
+            href: $path("/workflows"),
+        };
+};
+
+export const handle: RouteHandle = {
+    breadcrumb: ({ search }) =>
+        [getFromBreadcrumb(search), { content: "Threads" }].filter((x) => !!x),
+};

--- a/ui/admin/app/routes/_auth.tools._index.tsx
+++ b/ui/admin/app/routes/_auth.tools._index.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import useSWR, { preload } from "swr";
 
 import { ToolReferenceService } from "~/lib/service/api/toolreferenceService";
+import { RouteHandle } from "~/lib/service/routeHandles";
 
 import { TypographyH2 } from "~/components/Typography";
 import { ErrorDialog } from "~/components/composed/ErrorDialog";
@@ -113,3 +114,7 @@ export default function Tools() {
         </ScrollArea>
     );
 }
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: "Tools" }],
+};

--- a/ui/admin/app/routes/_auth.users.tsx
+++ b/ui/admin/app/routes/_auth.users.tsx
@@ -7,6 +7,7 @@ import { Thread } from "~/lib/model/threads";
 import { User, roleToString } from "~/lib/model/users";
 import { ThreadsService } from "~/lib/service/api/threadsService";
 import { UserService } from "~/lib/service/api/userService";
+import { RouteHandle } from "~/lib/service/routeHandles";
 import { pluralize, timeSince } from "~/lib/utils";
 
 import { TypographyH2, TypographyP } from "~/components/Typography";
@@ -112,3 +113,7 @@ export default function Users() {
 }
 
 const columnHelper = createColumnHelper<User>();
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: "Users" }],
+};

--- a/ui/admin/app/routes/_auth.webhooks.$webhook.tsx
+++ b/ui/admin/app/routes/_auth.webhooks.$webhook.tsx
@@ -1,7 +1,12 @@
-import { ClientLoaderFunctionArgs, useLoaderData } from "@remix-run/react";
+import {
+    ClientLoaderFunctionArgs,
+    useLoaderData,
+    useMatch,
+} from "@remix-run/react";
 import useSWR, { preload } from "swr";
 
 import { WebhookApiService } from "~/lib/service/api/webhookApiService";
+import { RouteHandle } from "~/lib/service/routeHandles";
 import { RouteService } from "~/lib/service/routeService";
 
 import { WebhookForm } from "~/components/webhooks/WebhookForm";
@@ -34,3 +39,18 @@ export default function Webhook() {
 
     return <WebhookForm webhook={webhook} />;
 }
+
+const WebhookBreadcrumb = () => {
+    const match = useMatch("/webhooks/:webhook");
+
+    const { data: webhook } = useSWR(
+        WebhookApiService.getWebhookById.key(match?.params.webhook || ""),
+        ({ id }) => WebhookApiService.getWebhookById(id)
+    );
+
+    return webhook?.name || webhook?.id || "Edit";
+};
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: <WebhookBreadcrumb /> }],
+};

--- a/ui/admin/app/routes/_auth.webhooks.create.tsx
+++ b/ui/admin/app/routes/_auth.webhooks.create.tsx
@@ -1,5 +1,11 @@
+import { RouteHandle } from "~/lib/service/routeHandles";
+
 import { WebhookForm } from "~/components/webhooks/WebhookForm";
 
 export default function CreateWebhookPage() {
     return <WebhookForm />;
 }
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: "Create" }],
+};

--- a/ui/admin/app/routes/_auth.webhooks.tsx
+++ b/ui/admin/app/routes/_auth.webhooks.tsx
@@ -1,0 +1,5 @@
+import { RouteHandle } from "~/lib/service/routeHandles";
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: "Webhooks" }],
+};

--- a/ui/admin/app/routes/_auth.workflows.$workflow.tsx
+++ b/ui/admin/app/routes/_auth.workflows.$workflow.tsx
@@ -2,13 +2,15 @@ import {
     ClientLoaderFunctionArgs,
     redirect,
     useLoaderData,
+    useMatch,
     useNavigate,
 } from "@remix-run/react";
 import { useCallback } from "react";
 import { $path } from "remix-routes";
-import { preload } from "swr";
+import useSWR, { preload } from "swr";
 
 import { WorkflowService } from "~/lib/service/api/workflowService";
+import { RouteHandle } from "~/lib/service/routeHandles";
 import { RouteQueryParams, RouteService } from "~/lib/service/routeService";
 
 import { Chat } from "~/components/chat";
@@ -88,3 +90,18 @@ export default function ChatAgent() {
         </div>
     );
 }
+
+const WorkflowBreadcrumb = () => {
+    const match = useMatch("/workflows/:workflow");
+
+    const { data: workflow } = useSWR(
+        WorkflowService.getWorkflowById.key(match?.params.workflow || ""),
+        ({ workflowId }) => WorkflowService.getWorkflowById(workflowId)
+    );
+
+    return workflow?.name;
+};
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: <WorkflowBreadcrumb /> }],
+};

--- a/ui/admin/app/routes/_auth.workflows.tsx
+++ b/ui/admin/app/routes/_auth.workflows.tsx
@@ -1,0 +1,5 @@
+import { RouteHandle } from "~/lib/service/routeHandles";
+
+export const handle: RouteHandle = {
+    breadcrumb: () => [{ content: "Workflows" }],
+};


### PR DESCRIPTION
Improves breadcrumb logic by using Remix Route Handles.

- breadcrumbs will now be defined at the route level
- this should make it much easier to remember to add a breadcrumb when implementing a new page
- encourages better practices for route nesting and route naming conventions

further reading for context:
https://remix.run/docs/zh/main/guides/breadcrumbs