### PR TITLE
fix: adds model provider in dropdown options for default models

### DIFF
--- a/ui/admin/app/components/agent/AgentForm.tsx
+++ b/ui/admin/app/components/agent/AgentForm.tsx
@@ -137,9 +137,10 @@ export function AgentForm({ agent, onSubmit, onChange }: AgentFormProps) {
 
                                 {models.map((m) => (
                                     <SelectItem key={m.id} value={m.id}>
-                                        {m.name || m.id}{" "}
+                                        {m.name || m.id}
+                                        {" - "}
                                         <span className="text-muted-foreground">
-                                            ({m.modelProvider})
+                                            {m.modelProvider}
                                         </span>
                                     </SelectItem>
                                 ))}

--- a/ui/admin/app/components/model/DefaultModelAliasForm.tsx
+++ b/ui/admin/app/components/model/DefaultModelAliasForm.tsx
@@ -258,9 +258,10 @@ export function DefaultModelAliasForm({
 
                         {otherModels.map((model) => (
                             <SelectItem key={model.id} value={model.id}>
-                                {model.name || model.id}{" "}
+                                {model.name || model.id}
+                                {" - "}
                                 <span className="text-muted-foreground">
-                                    ({model.modelProvider})
+                                    {model.modelProvider}
                                 </span>
                             </SelectItem>
                         ))}
@@ -279,10 +280,9 @@ function getModelOptionLabel(model: Model, aliasFor: ModelAlias) {
             {model.name || model.id}{" "}
             {suggestionName === model.name && (
                 <span className="text-muted-foreground">(Suggested)</span>
-            )}{" "}
-            <span className="text-muted-foreground">
-                ({model.modelProvider})
-            </span>
+            )}
+            {" - "}
+            <span className="text-muted-foreground">{model.modelProvider}</span>
         </>
     );
 }

--- a/ui/admin/app/components/model/DefaultModelAliasForm.tsx
+++ b/ui/admin/app/components/model/DefaultModelAliasForm.tsx
@@ -258,7 +258,10 @@ export function DefaultModelAliasForm({
 
                         {otherModels.map((model) => (
                             <SelectItem key={model.id} value={model.id}>
-                                {model.name || model.id}
+                                {model.name || model.id}{" "}
+                                <span className="text-muted-foreground">
+                                    ({model.modelProvider})
+                                </span>
                             </SelectItem>
                         ))}
                     </SelectGroup>
@@ -271,16 +274,17 @@ export function DefaultModelAliasForm({
 function getModelOptionLabel(model: Model, aliasFor: ModelAlias) {
     // if the model name is the same as the suggested model name, show that it's suggested
     const suggestionName = SUGGESTED_MODEL_SELECTIONS[aliasFor];
-    if (suggestionName === model.name) {
-        return (
-            <>
-                {model.name || model.id}{" "}
+    return (
+        <>
+            {model.name || model.id}{" "}
+            {suggestionName === model.name && (
                 <span className="text-muted-foreground">(Suggested)</span>
-            </>
-        );
-    }
-
-    return model.name || model.id;
+            )}{" "}
+            <span className="text-muted-foreground">
+                ({model.modelProvider})
+            </span>
+        </>
+    );
 }
 
 export function DefaultModelAliasFormDialog({


### PR DESCRIPTION
* adds model provider in dropdown like in agent models dropdown 
<img width="493" alt="Screenshot 2024-12-13 at 3 32 50 PM" src="https://github.com/user-attachments/assets/63390094-a3b3-43c1-a57e-2d60e6a262ae" />

* only thing about this is a little busy and drowns out (Suggested), not sure if a smaller font size for the provider would help