### PR TITLE
fix: prevent display of tool call output events

### DIFF
--- a/ui/admin/app/components/chat/ChatContext.tsx
+++ b/ui/admin/app/components/chat/ChatContext.tsx
@@ -153,7 +153,8 @@ function useMessageSource(threadId?: Nullish<string>) {
                 return copy;
             }
 
-            if (toolCall) {
+            // skip tool call output events
+            if (toolCall && !toolCall.output) {
                 copy.push(toolCallMessage(toolCall));
                 return copy;
             }

--- a/ui/admin/app/lib/model/chatEvents.ts
+++ b/ui/admin/app/lib/model/chatEvents.ts
@@ -7,6 +7,7 @@ export type ToolCall = {
     name: string;
     description: string;
     input: string;
+    output: string;
     metadata?: {
         category?: string;
         icon?: string;


### PR DESCRIPTION
addresses #854 

Before:
![image](https://github.com/user-attachments/assets/b05c76b9-9246-434a-8778-ef4e0a890a0e)

After:
![image](https://github.com/user-attachments/assets/b71e9d29-9f81-4d12-bf05-93ce55aa470e)

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>